### PR TITLE
Rewrite core

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
     "env": {
         "mocha": true
     },
-    "extends": "airbnb-base"
+    "extends": "airbnb-base",
+    "rules": {
+        "no-underscore-dangle": ["error", { "allow": ["_stack", "_layer", "_idx", "_next"] }]
+    }
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn add next-connect
 
 `next-connect` is used in **Next.js 9 [API Routes](https://nextjs.org/docs#api-routes)** (those in `/pages/api/`). The usage is similar to [Express.js](https://github.com/expressjs/express/) but without `path` as the first argument.
 
-When doing `export default`, use `handler.export()`.
+When doing `export default`, use `handler`.
 
 ```javascript
 import nextConnect from 'next-connect'
@@ -38,13 +38,13 @@ handler.post(function (req, res) {
     res.json('Hi there');
 });
 
-//  export using handler.export()
-export default handler.export();
+//  export using handler
+export default handler;
 ```
 
 ### Use middleware
 
-Middleware is the core of `next-connect`. Middlewares are added as "stack" where the request and response object can be manipulated one-by-one as long as `next()` is called.
+Middleware is the core of `next-connect`. Middlewares are added as layers of a "stack" where the request and response will be routed through each layer one-by-one as long as `next()` is called.
 
 `handler.use(fn)`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 function constructLayer(method, handler, isErrorMiddleware = false) {
   return {
     handle: handler,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-function constructStack(method, handler, isErrorMiddleware = false) {
+function constructLayer(method, handler, isErrorMiddleware = false) {
   return {
     handle: handler,
     method,
@@ -7,67 +7,65 @@ function constructStack(method, handler, isErrorMiddleware = false) {
   };
 }
 
-class NextConnect {
-  constructor() {
-    this.stacks = [];
-    this.ended = true;
-    //  routing methods
+const proto = {};
 
-    const httpMethods = ['get', 'post', 'put', 'patch', 'delete'];
-    httpMethods.forEach((method) => {
-      this[method] = (...args) => {
-        args.forEach((handler) => {
-          this.stacks.push(constructStack(method, handler));
-        });
-      };
-    });
+const httpMethods = ['get', 'post', 'put', 'patch', 'delete'];
+httpMethods.forEach((method) => {
+  proto[method] = function (...args) {
+    for (let i = 0; i < args.length; i += 1) {
+      this.stack.push(constructLayer(method, args[i]));
+    }
+  };
+});
+
+proto.use = function use(handler) {
+  this.stack.push(constructLayer('*', handler));
+};
+
+proto.error = function error(handler) {
+  this.stack.push(constructLayer('*', handler, true));
+};
+
+proto.handle = function handle(req, res) {
+  const _stack = this.stack;
+  let _idx = 0;
+  async function _next(nextErr) {
+    const _layer = _stack[_idx];
+    _idx += 1;
+
+    //  all done
+    if (!_layer) return;
+
+    //  check if is correct method or middleware
+    if (_layer.method !== '*' && _layer.method !== req.method.toLowerCase()) {
+      _next(nextErr);
+      return;
+    }
+
+    try {
+      if (nextErr) {
+        //  there is an error
+        if (_layer.isErrorMiddleware || _layer.handle.length === 4) {
+          await _layer.handle(nextErr, req, res, _next);
+        } else throw nextErr;
+      } else await _layer.handle(req, res, _next);
+    } catch (err) {
+      _next(err);
+    }
   }
 
-  use(handler) {
-    this.stacks.push(constructStack('*', handler));
+  //  Init stack chain
+  _next();
+};
+
+function nextConnect() {
+  function connect(req, res) {
+    connect.handle(req, res);
   }
+  Object.assign(connect, proto);
+  connect.stack = [];
 
-  error(handler) {
-    this.stacks.push(constructStack('*', handler, true));
-  }
-
-  export() {
-    return (req, res) => {
-      const _stacks = this.stacks;
-      let _idx = 0;
-      async function _next(nextErr) {
-        const _layer = _stacks[_idx];
-        _idx += 1;
-
-        //  all done
-        if (!_layer) return;
-
-        if (
-          _layer.method !== '*'
-          && _layer.method !== req.method.toLowerCase()
-        ) {
-          _next(nextErr);
-          return;
-        }
-
-        //  Method matched or is middleware
-        try {
-          if (nextErr) {
-            //  there is an error
-            if (_layer.isErrorMiddleware || _layer.handle.length === 4) {
-              await _layer.handle(nextErr, req, res, _next);
-            } else throw nextErr;
-          } else await _layer.handle(req, res, _next);
-        } catch (err) {
-          _next(err);
-        }
-      }
-
-      //  Init stack chains
-      _next();
-    };
-  }
+  return connect;
 }
 
-module.exports = () => new NextConnect();
-module.exports.NextConnect = NextConnect;
+module.exports = nextConnect;


### PR DESCRIPTION
This PR rewrite the approach of `next-connect`.

We no longer need to call `.export()` and instead can simply `export default` the `handler` (`nextConnect()`)