### PR TITLE
Add support for non-api pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,29 @@ export default handler;
 //  Navigating to /api/somePostRoute in the browser will render 404.
 ```
 
+### Document middleware and getInitialProps
+
+To use `next-connect` in [document middleware](https://github.com/zeit/next.js/issues/7208) or `getInitialProps`, use `handler.apply(req, res)`.
+
+```javascript
+// page/_document.js
+export async function middleware({req, res}: PageContext) {
+    const handler = nextConnect();
+    handler.use(someMiddleware());
+    // await calling .apply
+    await handler.apply(req, res);
+}
+
+// OR
+// page/somePage.js
+Page.getInitialProps = async ({ req, res }) => {
+  const handler = nextConnect();
+  handler.use(someMiddleware());
+  await handler.apply(req, res);
+  return { ...whatEverYourLittleDesires }
+}
+```
+
 ## Contributing
 
 Please see my [contributing.md](CONTRIBUTING.md).

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,11 @@ proto.error = function error(handler) {
   this.stack.push(constructLayer('*', handler, true));
 };
 
-proto.handle = function handle(req, res) {
+proto.apply = function apply(req, res) {
+  return new Promise((resolve) => this.handle(req, res, resolve));
+};
+
+proto.handle = function handle(req, res, done) {
   const _stack = this.stack;
   let _idx = 0;
   async function _next(nextErr) {
@@ -35,7 +39,8 @@ proto.handle = function handle(req, res) {
 
     //  all done
     if (!_layer) {
-      if (!res.headersSent) res.writeHead(404).end();
+      if (done) done();
+      else if (!res.headersSent) res.writeHead(404).end();
       return;
     }
 

--- a/test/index.text.js
+++ b/test/index.text.js
@@ -88,6 +88,17 @@ describe('nextConnect', () => {
     });
   });
 
+  context('non-api support', () => {
+    it('apply() should apply middleware to req and res', () => {
+      handler.use((req, res, next) => { req.hello = 'world'; next(); });
+      const app = createServer(async (req, res) => {
+        await handler.apply(req, res);
+        res.end(req.hello || '');
+      });
+      return request(app).get('/').expect('world');
+    });
+  });
+
   context('error handling', () => {
     it('use() with 4 args should work as an error middleware', () => {
       handler.get((req, res) => {


### PR DESCRIPTION
Close #4 

Introduce `.apply(req, res)`