### PR TITLE
Add onError and onNoMatch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,10 @@ function onerror(err, req, res) {
   res.end(err.message || res.statusCode.toString());
 }
 
-module.exports = ({ onError = onerror, onNoMatch = onerror.bind(null, { code: 404 }) } = {}) => {
+module.exports = ({
+  onError = onerror,
+  onNoMatch = onerror.bind(null, { code: 404, message: 'not found' }),
+} = {}) => {
   function connect(req, res) {
     connect.handle(req, res);
   }
@@ -14,6 +17,7 @@ module.exports = ({ onError = onerror, onNoMatch = onerror.bind(null, { code: 40
   function add(...args) {
     if (typeof args[1] !== 'string') args.splice(1, 0, '*');
     router.add.apply(connect, args);
+    return connect;
   }
   // method routing
   connect.get = add.bind(connect, 'GET');
@@ -31,20 +35,12 @@ module.exports = ({ onError = onerror, onNoMatch = onerror.bind(null, { code: 40
       setImmediate(fn.handle.bind(fn), req, res, next);
     }
     : fn);
+
   connect.use = function use(base, ...fns) {
     if (typeof base === 'string') {
       router.use.apply(connect, [base, fns.map(mount)]);
-    } else {
-      router.use.apply(connect, ['/', [base, ...fns].map(mount)]);
-    }
-  };
-  connect.error = function error(...fns) {
-    // eslint-disable-next-line no-unused-vars
-    connect.use(
-      ...fns.map((fn) => (typeof fn !== 'string'
-        ? (err, req, res, next) => fn(err, req, res, next)
-        : fn)),
-    );
+    } else router.use.apply(connect, ['/', [base, ...fns].map(mount)]);
+    return connect;
   };
 
   connect.find = router.find.bind(connect);
@@ -58,27 +54,22 @@ module.exports = ({ onError = onerror, onNoMatch = onerror.bind(null, { code: 40
     const { handlers } = this.find(req.method, req.url);
     async function next(err) {
       const handler = handlers[i];
-      i += 1;
 
       //  all done
       if (!handler) {
         if (done) done();
         else if (err) onError(err, req, res);
-        else if (res.writableEnded === false || res.finished === false) {
+        else if (
+          !err
+          && (res.writableEnded === false || res.finished === false)
+        ) {
           setImmediate(onNoMatch, req, res);
         }
         return;
       }
 
       try {
-        if (!err) {
-          handler(req, res, next);
-          return;
-        }
-        //  there is an error
-        if (handler.length === 4) {
-          handler(err, req, res, next);
-        } else next(err);
+        if (!err) { i += 1; handler(req, res, next); } else onError(err, req, res, next);
       } catch (error) {
         next(error);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,11 @@
 const Trouter = require('trouter');
 
-module.exports = () => {
+function onerror(err, req, res) {
+  res.statusCode = err.code || err.status || 500;
+  res.end(err.message || res.statusCode.toString());
+}
+
+module.exports = ({ onNoMatch = onerror.bind(null, { code: 404 }) } = {}) => {
   function connect(req, res) {
     connect.handle(req, res);
   }
@@ -49,16 +54,18 @@ module.exports = () => {
   };
 
   connect.handle = function handle(req, res, done) {
-    let idx = 0;
+    let i = 0;
     const { handlers } = this.find(req.method, req.url);
     async function next(err) {
-      const handler = handlers[idx];
-      idx += 1;
+      const handler = handlers[i];
+      i += 1;
 
       //  all done
       if (!handler) {
         if (done) done();
-        else if (!res.headersSent) res.writeHead(404).end();
+        else if (res.writableEnded === false || res.finished === false) {
+          setImmediate(onNoMatch, req, res);
+        }
         return;
       }
 
@@ -69,14 +76,13 @@ module.exports = () => {
         }
         //  there is an error
         if (handler.length === 4) {
-          await handler(err, req, res, next);
+          handler(err, req, res, next);
         } else next(err);
       } catch (error) {
         next(error);
       }
     }
 
-    //  Init stack chain
     next();
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ function onerror(err, req, res) {
   res.end(err.message || res.statusCode.toString());
 }
 
-module.exports = ({ onNoMatch = onerror.bind(null, { code: 404 }) } = {}) => {
+module.exports = ({ onError = onerror, onNoMatch = onerror.bind(null, { code: 404 }) } = {}) => {
   function connect(req, res) {
     connect.handle(req, res);
   }
@@ -63,6 +63,7 @@ module.exports = ({ onNoMatch = onerror.bind(null, { code: 404 }) } = {}) => {
       //  all done
       if (!handler) {
         if (done) done();
+        else if (err) onError(err, req, res);
         else if (res.writableEnded === false || res.finished === false) {
           setImmediate(onNoMatch, req, res);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,33 +28,27 @@ module.exports = ({
   connect.options = add.bind(connect, 'OPTIONS');
   connect.trace = add.bind(connect, 'TRACE');
   connect.patch = add.bind(connect, 'PATCH');
-
   // middleware
   const mount = (fn) => (fn.routes
     ? (req, res, next) => {
       setImmediate(fn.handle.bind(fn), req, res, next);
     }
     : fn);
-
   connect.use = function use(base, ...fns) {
     if (typeof base === 'string') {
       router.use.apply(connect, [base, fns.map(mount)]);
     } else router.use.apply(connect, ['/', [base, ...fns].map(mount)]);
     return connect;
   };
-
   connect.find = router.find.bind(connect);
-
   connect.apply = function apply(req, res) {
     return new Promise((resolve) => this.handle(req, res, resolve));
   };
-
   connect.handle = function handle(req, res, done) {
     let i = 0;
     const { handlers } = this.find(req.method, req.url);
     async function next(err) {
       const handler = handlers[i];
-
       //  all done
       if (!handler) {
         if (done) done();
@@ -67,14 +61,15 @@ module.exports = ({
         }
         return;
       }
-
       try {
-        if (!err) { i += 1; handler(req, res, next); } else onError(err, req, res, next);
+        if (!err) {
+          i += 1;
+          handler(req, res, next);
+        } else onError(err, req, res, next);
       } catch (error) {
         next(error);
       }
     }
-
     next();
   };
 

--- a/test/index.text.js
+++ b/test/index.text.js
@@ -165,6 +165,16 @@ describe('nextConnect', () => {
         })
         .expect('error');
     });
+
+    it('should default to onerror', () => {
+      handler.get((req, res) => {
+        throw new Error('error');
+      });
+      const app = createServer(handler);
+      return request(app)
+        .get('/')
+        .expect(500);
+    });
   });
 
   context('init', () => {


### PR DESCRIPTION
`onNoMatch` allows custom 404 page.

We are deprecating error middleware in favor of `onError` like `polka`.

This makes sense because error middleware must be call every time (old approach will discard the error middleware after it is called). Also it is difficult to always have error middleware at the end.