### PR TITLE
Fix uncaught error in non-async functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ handler
   })
   .post((req, res) => {
     res.json({ hello: 'world' });
+  })
+  .put(async (req, res) => {
+    res.end('async/await is also supported!');
   });
 
 export default handler;
@@ -189,10 +192,11 @@ const http = require('http');
 handler
   .use(someMiddleware())
   .get((req, res) => {
-    res.send("Hello world");
+    res.end('Hello world');
   })
   .post((req, res) => {
-    res.json({ hello: 'world' });
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ hello: 'world' }));
   });
 
 http.createServer(handler).listen(PORT);

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,13 +49,13 @@ module.exports = ({
     const { handlers } = this.find(req.method, req.url);
     let i = 0;
     const len = handlers.length;
-    const next = (err) =>
+    const next = async (err) =>
       i < len
         ? err
           ? onError(err, req, res, next)
-          : Promise.resolve(handlers[i++](req, res, next)).catch(next)
+          : handlers[i++](req, res, next)
         : done && done(err);
-    next();
+    next().catch(next);
   };
 
   return connect;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -126,16 +126,17 @@ describe('nextConnect', () => {
       const app = createServer(handler);
       return request(app)
         .get('/')
-        .expect(500);
+        .expect(500)
+        .expect('error')
     });
     it('should use custom onError', async () => {
       function onError(err, req, res, next) {
         res.end('One does not simply ignore error');
       }
       const handler2 = nextConnect({ onError });
-      handler2.get((req, res, next) => { next(Error()); });
+      handler2.get((req, res, next) => { throw new Error('wackk'); });
       const app = createServer(handler2);
-      await request(app).get('/').expect(200);
+      await request(app).get('/').expect(200).expect('One does not simply ignore error');
     });
     it('should continue chain with next', () => {
       function onError(err, req, res, next) {
@@ -143,7 +144,7 @@ describe('nextConnect', () => {
       }
       const handler2 = nextConnect({ onError });
       handler2
-        .get((req, res, next) => { next(Error()); })
+        .get((req, res, next) => { throw new Error() })
         .get((req, res) => res.end('no error'));
       const app = createServer(handler2);
       return request(app).get('/').expect('no error');


### PR DESCRIPTION
While we successfully catch error in async function, non-async function's error is missed.