### PR TITLE
Fix TypeScript signature and support both API and non-API pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,9 @@ import nc from 'next-connect';
 const handler = nc<NextApiRequest, NextApiResponse>()
 ```
 
-In individual handler, you can also define custom properties to `req` and `res` (such as `req.user` or `res.cookie`) like so:
+In each handler, you can also define custom properties to `req` and `res` (such as `req.user` or `res.cookie`) like so:
 
 ```typescript
-
 interface ExtendedRequest { user: string };
 interface ExtendedResponse { cookie: (name: string, value: string) => void };
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ See an example in [nextjs-mongodb-app](https://github.com/hoangvvo/nextjs-mongod
 By default, the base interfaces of `req` and `res` are `IncomingMessage` and `ServerResponse`. When using in API Routes, you would set them to `NextApiRequest` and `NextApiResponse` by providing the generics to the factory function like so:
 
 ```typescript
+import { NextApiRequest, NextApiResponse } from 'next';
 import nc from 'next-connect';
 
 const handler = nc<NextApiRequest, NextApiResponse>()

--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ For usage in pages with [`getServerSideProps`](https://nextjs.org/docs/basic-fea
 
 See an example in [nextjs-mongodb-app](https://github.com/hoangvvo/nextjs-mongodb-app) (CRUD, Authentication with Passport, and more)
 
+### TypeScript
+
+By default, the base interfaces of `req` and `res` are `IncomingMessage` and `ServerResponse`. When using in API Routes, you would set them to `NextApiRequest` and `NextApiResponse` by providing the generics to the factory function like so:
+
+```typescript
+import nc from 'next-connect';
+
+const handler = nc<NextApiRequest, NextApiResponse>()
+```
+
+In individual handler, you can also define custom properties to `req` and `res` (such as `req.user` or `res.cookie`) like so:
+
+```typescript
+
+interface ExtendedRequest { user: string };
+interface ExtendedResponse { cookie: (name: string, value: string) => void };
+
+handler.post<ExtendedRequest, ExtendedResponse>((req, res) => {
+  req.user = 'Anakin';
+  res.cookie('sid', '8108');
+})
+```
+
 ## API
 
 The API is similar to [Express.js](https://github.com/expressjs/express) with several differences:

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,66 +2,66 @@ declare module "next-connect" {
   import { IncomingMessage, ServerResponse } from "http";
 
   type NextHandler = (err?: any) => void;
-  type Middleware<T = {}, S = {}> = NextConnect | RequestHandler<T, S>;
+  type Middleware<T, S> = NextConnect<T, S> | RequestHandler<T, S>;
 
-  type RequestHandler<T = {}, S = {}> = (
-    req: IncomingMessage & T,
-    res: ServerResponse & S,
+  type RequestHandler<T, S> = (
+    req: T,
+    res: S,
     next: NextHandler
   ) => void;
 
-  type ErrorHandler = (
+  type ErrorHandler<T, S> = (
     err: any,
-    req: IncomingMessage,
-    res: ServerResponse,
+    req: T,
+    res: S,
     next: NextHandler
   ) => void;
 
-  interface Options {
-    onError?: ErrorHandler;
-    onNoMatch?: RequestHandler;
+  interface Options<T, S> {
+    onError?: ErrorHandler<T, S>;
+    onNoMatch?: RequestHandler<T, S>;
   }
 
-  function NextConnect(
-    req: IncomingMessage,
-    res: ServerResponse
+  function NextConnect<TT, SS>(
+    req: TT,
+    res: SS
   ): Promise<void>;
 
-  interface NextConnect {
-    readonly onError: ErrorHandler;
-    readonly onNoMatch: RequestHandler;
+  interface NextConnect<TT, SS> {
+    readonly onError: ErrorHandler<TT, SS>;
+    readonly onNoMatch: RequestHandler<TT, SS>;
 
-    use<T = {}, S = {}>(...handlers: Middleware<T, S>[]): this;
-    use<T = {}, S = {}>(pattern: string | RegExp, ...handlers: Middleware<T, S>[]): this;
+    use<T = {}, S = {}>(...handlers: Middleware<TT & T, SS & S>[]): this;
+    use<T = {}, S = {}>(pattern: string | RegExp, ...handlers: Middleware<TT & T, SS & S>[]): this;
 
-    get<T = {}, S = {}>(...handlers: RequestHandler<T, S>[]): this;
-    get<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<T, S>[]): this;
+    get<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    get<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    head<T = {}, S = {}>(...handlers: RequestHandler<T, S>[]): this;
-    head<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<T, S>[]): this;
+    head<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    head<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    post<T = {}, S = {}>(...handlers: RequestHandler<T, S>[]): this;
-    post<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<T, S>[]): this;
+    post<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    post<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    put<T = {}, S = {}>(...handlers: RequestHandler<T, S>[]): this;
-    put<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<T, S>[]): this;
+    put<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    put<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    delete<T = {}, S = {}>(...handlers: RequestHandler<T, S>[]): this;
-    delete<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<T, S>[]): this;
+    delete<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    delete<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    options<T = {}, S = {}>(...handlers: RequestHandler<T, S>[]): this;
-    options<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<T, S>[]): this;
+    options<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    options<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    trace<T = {}, S = {}>(...handlers: RequestHandler<T, S>[]): this;
-    trace<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<T, S>[]): this;
+    trace<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    trace<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    patch<T = {}, S = {}>(...handlers: RequestHandler<T, S>[]): this;
-    patch<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<T, S>[]): this;
+    patch<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    patch<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    apply(req: IncomingMessage, res: ServerResponse): Promise<void>;
+    apply(req: TT, res: SS): Promise<void>;
 
-    handle(req: IncomingMessage, res: ServerResponse, done: NextHandler): void;
+    handle(req: TT, res: SS, done: NextHandler): void;
   }
 
-  export default function (options?: Options): NextConnect;
+  export default function <T = IncomingMessage, S = ServerResponse>(options?: Options<T, S>): NextConnect<T, S>;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -28,9 +28,6 @@ declare module "next-connect" {
   ): Promise<void>;
 
   interface NextConnect<U, V> {
-    readonly onError: ErrorHandler<U, V>;
-    readonly onNoMatch: RequestHandler<U, V>;
-
     use<T = {}, S = {}>(...handlers: Middleware<U & T, V & S>[]): this;
     use<T = {}, S = {}>(pattern: string | RegExp, ...handlers: Middleware<U & T, V & S>[]): this;
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -31,32 +31,32 @@ declare module "next-connect" {
     readonly onError: ErrorHandler<TT, SS>;
     readonly onNoMatch: RequestHandler<TT, SS>;
 
-    use<T = {}, S = {}>(...handlers: Middleware<TT & T, SS & S>[]): this;
-    use<T = {}, S = {}>(pattern: string | RegExp, ...handlers: Middleware<TT & T, SS & S>[]): this;
+    use<T = TT, S = SS>(...handlers: Middleware<TT & T, SS & S>[]): this;
+    use<T = TT, S = SS>(pattern: string | RegExp, ...handlers: Middleware<TT & T, SS & S>[]): this;
 
-    get<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    get<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    get<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    get<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    head<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    head<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    head<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    head<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    post<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    post<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    post<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    post<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    put<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    put<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    put<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    put<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    delete<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    delete<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    delete<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    delete<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    options<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    options<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    options<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    options<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    trace<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    trace<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    trace<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    trace<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
-    patch<T = {}, S = {}>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    patch<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    patch<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    patch<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
 
     apply(req: TT, res: SS): Promise<void>;
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -22,45 +22,45 @@ declare module "next-connect" {
     onNoMatch?: RequestHandler<T, S>;
   }
 
-  function NextConnect<TT, SS>(
-    req: TT,
-    res: SS
+  function NextConnect<U, V>(
+    req: U,
+    res: V
   ): Promise<void>;
 
-  interface NextConnect<TT, SS> {
-    readonly onError: ErrorHandler<TT, SS>;
-    readonly onNoMatch: RequestHandler<TT, SS>;
+  interface NextConnect<U, V> {
+    readonly onError: ErrorHandler<U, V>;
+    readonly onNoMatch: RequestHandler<U, V>;
 
-    use<T = TT, S = SS>(...handlers: Middleware<TT & T, SS & S>[]): this;
-    use<T = TT, S = SS>(pattern: string | RegExp, ...handlers: Middleware<TT & T, SS & S>[]): this;
+    use<T = {}, S = {}>(...handlers: Middleware<U & T, V & S>[]): this;
+    use<T = {}, S = {}>(pattern: string | RegExp, ...handlers: Middleware<U & T, V & S>[]): this;
 
-    get<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    get<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    get<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
+    get<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
 
-    head<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    head<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    head<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
+    head<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
 
-    post<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    post<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    post<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
+    post<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
 
-    put<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    put<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    put<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
+    put<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
 
-    delete<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    delete<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    delete<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
+    delete<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
 
-    options<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    options<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    options<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
+    options<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
 
-    trace<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    trace<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    trace<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
+    trace<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
 
-    patch<T = TT, S = SS>(...handlers: RequestHandler<TT & T, SS & S>[]): this;
-    patch<T = TT, S = SS>(pattern: string | RegExp, ...handlers: RequestHandler<TT & T, SS & S>[]): this;
+    patch<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
+    patch<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
 
-    apply(req: TT, res: SS): Promise<void>;
+    apply(req: U, res: V): Promise<void>;
 
-    handle(req: TT, res: SS, done: NextHandler): void;
+    handle(req: U, res: V, done: NextHandler): void;
   }
 
   export default function <T = IncomingMessage, S = ServerResponse>(options?: Options<T, S>): NextConnect<T, S>;


### PR DESCRIPTION
Relate #69.

I'm thinking of a new approach to the type definitions that allows me to support both of them.

This is what I'm thinking:

```
import { NextApiResponse, NextApiRequest } from 'next';
import nc from 'next-connect';

// Default: <IncomingMessage, ServerResponse>
const handler = nc<NextApiResponse, NextApiResponse>()

interface ExtendedRequest { session: SessionData };
interface ExtendedResponse { cookie: (name: string, value: string) => void };

// Default: <{}, {}>
handler.get<ExtendedRequest, ExtendedResponse>((req, res) => {
  req.session.test = 'ok';
  res.cookie('this', 'that');
})
```

The generics provided in the factory function will be merged to the generics of individual handlers.

Another good approach is this https://github.com/hoangvvo/next-connect/issues/69#issuecomment-650396465