### PR TITLE
Deprecate apply() for run()

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const handler = nc()
 export default handler;
 ```
 
-For usage in pages with [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering), see [`.apply`](#applyreq-res).
+For usage in pages with [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering), see [`.run`](#runreq-res).
 
 See an example in [nextjs-mongodb-app](https://github.com/hoangvvo/nextjs-mongodb-app) (CRUD, Authentication with Passport, and more)
 
@@ -184,9 +184,9 @@ However, since Next.js already handles routing (including dynamic routes), we of
 
 Same as [.METHOD](#methodpattern-fns) but accepts *any* methods.
 
-### .apply(req, res)
+### .run(req, res)
 
-Applies the middleware and returns a **promise** after which you can use the upgraded `req` and `res`.
+Runs `req` and `res` the middleware and returns a **promise**. It will **not** render `404` on not found or `onError` on error.
 
 This can be useful in [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering).
 
@@ -197,7 +197,7 @@ export async function getServerSideProps({ req, res }) {
     .use(passport.initialize())
     .post(postMiddleware);
   try {
-    await handler.apply(req, res);
+    await handler.run(req, res);
   } catch (e) {
     // handle the error
   }
@@ -208,8 +208,6 @@ export async function getServerSideProps({ req, res }) {
 }
 
 ```
-
-**Warning:** `.apply` is not meant to be used as a request handler because it does not render `404` or `onError` accordingly.
 
 ## Using in other frameworks
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -58,6 +58,8 @@ declare module "next-connect" {
     patch<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
     patch<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
 
+    run(req: U, res: V): Promise<void>;
+    /** @deprecated */
     apply(req: U, res: V): Promise<void>;
 
     handle(req: U, res: V, done: NextHandler): void;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
-const Trouter = require('trouter');
+const Trouter = require("trouter");
+const { deprecate } = require("util");
 
 function onerror(err, req, res) {
   res.statusCode = err.code || err.status || 500;
@@ -10,50 +11,51 @@ const mount = (fn) => (fn.routes ? fn.handle.bind(fn) : fn);
 
 module.exports = ({
   onError = onerror,
-  onNoMatch = onerror.bind(null, { code: 404, message: 'not found' }),
+  onNoMatch = onerror.bind(null, { code: 404, message: "not found" }),
 } = {}) => {
-  function connect(req, res) {
-    return connect.apply(req, res).then(
+  function nc(req, res) {
+    return nc.run(req, res).then(
       () => !isResSent(res) && onNoMatch(req, res),
       (err) => onError(err, req, res)
     );
   }
   const router = new Trouter();
-  connect.routes = [];
+  nc.routes = [];
   function add(...args) {
-    if (typeof args[1] !== 'string') args.splice(1, 0, '*');
-    router.add.apply(connect, args);
-    return connect;
+    if (typeof args[1] !== "string") args.splice(1, 0, "*");
+    router.add.apply(nc, args);
+    return nc;
   }
-  connect.all = add.bind(connect, '');
-  connect.get = add.bind(connect, 'GET');
-  connect.head = add.bind(connect, 'HEAD');
-  connect.post = add.bind(connect, 'POST');
-  connect.put = add.bind(connect, 'PUT');
-  connect.delete = add.bind(connect, 'DELETE');
-  connect.options = add.bind(connect, 'OPTIONS');
-  connect.trace = add.bind(connect, 'TRACE');
-  connect.patch = add.bind(connect, 'PATCH');
-  connect.use = function use(base, ...fns) {
-    if (typeof base === 'string') {
-      router.use.apply(connect, [
+  nc.all = add.bind(nc, "");
+  nc.get = add.bind(nc, "GET");
+  nc.head = add.bind(nc, "HEAD");
+  nc.post = add.bind(nc, "POST");
+  nc.put = add.bind(nc, "PUT");
+  nc.delete = add.bind(nc, "DELETE");
+  nc.options = add.bind(nc, "OPTIONS");
+  nc.trace = add.bind(nc, "TRACE");
+  nc.patch = add.bind(nc, "PATCH");
+  nc.use = function use(base, ...fns) {
+    if (typeof base === "string") {
+      router.use.apply(nc, [
         base,
         fns.map((fn) => {
           fn.baseUrl = base;
           return mount(fn);
         }),
       ]);
-    } else router.use.apply(connect, ['/', [base, ...fns].map(mount)]);
-    return connect;
+    } else router.use.apply(nc, ["/", [base, ...fns].map(mount)]);
+    return nc;
   };
-  connect.find = router.find.bind(connect);
-  connect.apply = function apply(req, res) {
+  nc.find = router.find.bind(nc);
+  nc.run = function run(req, res) {
     return new Promise((resolve, reject) => {
       this.handle(req, res, (err) => (err ? reject(err) : resolve()));
     });
   };
-  connect.handle = function handle(req, res, done) {
-    const idx = req.url.indexOf('?');
+  nc.apply = deprecate(nc.run, "next-connect: apply() is deprecated. Use run() instead.");
+  nc.handle = function handle(req, res, done) {
+    const idx = req.url.indexOf("?");
     const pathname = idx !== -1 ? req.url.substring(0, idx) : req.url;
     const { handlers } = this.find(
       req.method,
@@ -67,11 +69,11 @@ module.exports = ({
           ? onError(err, req, res, next)
           : loop().catch(next)
         : done && done(err);
-    }
+    };
     async function loop() {
       return handlers[i++](req, res, next);
     }
     next();
   };
-  return connect;
+  return nc;
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,69 +1,81 @@
 /* eslint-disable no-unused-vars */
-const assert = require('assert');
+const assert = require("assert");
 //  Next.js API Routes behaves similar to Node HTTP Server
-const { createServer } = require('http');
-const request = require('supertest');
-const nc = require('../lib');
+const { createServer } = require("http");
+const request = require("supertest");
+const nc = require("../lib");
 
-const METHODS = ['get', 'head', 'post', 'put', 'delete', 'options', 'trace', 'patch'];
+const METHODS = [
+  "get",
+  "head",
+  "post",
+  "put",
+  "delete",
+  "options",
+  "trace",
+  "patch",
+];
 
-describe('nc()', () => {
-  it('is chainable', () => {
+describe("nc()", () => {
+  it("is chainable", () => {
     const handler = nc()
       .use(
         (req, res, next) => {
-          req.four = '4';
+          req.four = "4";
           next();
         },
         (req, res, next) => {
-          res.setHeader('2-plus-2-is', req.four);
+          res.setHeader("2-plus-2-is", req.four);
           next();
         }
       )
       .get((req, res) => {
         // minus 3 is 1
-        res.end('quick math');
+        res.end("quick math");
       });
     const app = createServer(handler);
     return request(app)
-      .get('/')
-      .expect('2-plus-2-is', '4')
-      .expect('quick math');
+      .get("/")
+      .expect("2-plus-2-is", "4")
+      .expect("quick math");
   });
 
-  it('supports async handlers', async () => {
+  it("supports async handlers", async () => {
     const handler = nc()
       .use(async (req, res, next) => {
-        res.setHeader('one', await new Promise(resolve => setTimeout(() => resolve('1'), 1)));
-        next()
+        res.setHeader(
+          "one",
+          await new Promise((resolve) => setTimeout(() => resolve("1"), 1))
+        );
+        next();
       })
-      .get((req, res) => new Promise(resolve => {
-        setTimeout(() => {
-          res.end('done');
-          resolve()
-        }, 1);
-      }));
+      .get(
+        (req, res) =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              res.end("done");
+              resolve();
+            }, 1);
+          })
+      );
     const app = createServer(handler);
-    return await request(app)
-      .get('/')
-      .expect('one', '1')
-      .expect('done');
+    return await request(app).get("/").expect("one", "1").expect("done");
   });
 
-  it('is a function with two argument', () => {
-    assert(typeof nc() === 'function' && nc().length === 2);
+  it("is a function with two argument", () => {
+    assert(typeof nc() === "function" && nc().length === 2);
   });
 
-  it('returns a promise', () => {
+  it("returns a promise", () => {
     nc()({}, { end: () => null }).then((e) => {
       /* no-op */
     });
   });
 });
 
-describe('.METHOD', () => {
-  it('match any path', () => {
-    const handler = nc()
+describe(".METHOD", () => {
+  it("match any path", () => {
+    const handler = nc();
     METHODS.forEach((method) => {
       handler[method]((req, res) => res.end(method));
     });
@@ -71,14 +83,16 @@ describe('.METHOD', () => {
     const requestPromises = [];
     METHODS.forEach((method) => {
       requestPromises.push(
-        request(app)[method](`/${method}`).expect(method !== 'head' ? method : undefined)
+        request(app)
+          [method](`/${method}`)
+          .expect(method !== "head" ? method : undefined)
       );
     });
     return Promise.all(requestPromises);
   });
 
-  it('match by path', () => {
-    const handler = nc()
+  it("match by path", () => {
+    const handler = nc();
     METHODS.forEach((method) => {
       handler[method](`/${method}`, (req, res) => res.end(method));
     });
@@ -86,194 +100,198 @@ describe('.METHOD', () => {
     const requestPromises = [];
     METHODS.forEach((method) => {
       requestPromises.push(
-        request(app)[method](`/${method}`).expect(method !== 'head' ? method : undefined)
+        request(app)
+          [method](`/${method}`)
+          .expect(method !== "head" ? method : undefined)
       );
     });
-    requestPromises.push(request(app).get('/yes').expect(404));
+    requestPromises.push(request(app).get("/yes").expect(404));
     return Promise.all(requestPromises);
   });
 });
 
-describe('all()', () => {
-  it('match any path of any methods', () => {
+describe("all()", () => {
+  it("match any path of any methods", () => {
     const handler = nc();
-    handler.all((req, res) => res.end('all'));
+    handler.all((req, res) => res.end("all"));
     const requestPromises = [];
     const app = createServer(handler);
     METHODS.forEach((method) => {
       requestPromises.push(
-        request(app)[method](`/${method}`).expect(method !== 'head' ? 'all' : undefined)
+        request(app)
+          [method](`/${method}`)
+          .expect(method !== "head" ? "all" : undefined)
       );
     });
     return Promise.all(requestPromises);
-  })
+  });
 
-  it('match by path of any methods', () => {
+  it("match by path of any methods", () => {
     const handler = nc();
-    handler.all('/all', (req, res) => res.end('all'));
+    handler.all("/all", (req, res) => res.end("all"));
     const requestPromises = [];
     const app = createServer(handler);
     METHODS.forEach((method) => {
-      requestPromises.push(
-        request(app)[method](`/${method}`).expect(404)
-      );
+      requestPromises.push(request(app)[method](`/${method}`).expect(404));
     });
     METHODS.forEach((method) => {
       requestPromises.push(
-        request(app)[method](`/all`).expect(method !== 'head' ? 'all' : undefined)
+        request(app)
+          [method](`/all`)
+          .expect(method !== "head" ? "all" : undefined)
       );
     });
     return Promise.all(requestPromises);
-  })
-})
+  });
+});
 
-describe('use()', () => {
-  it('match all without base', async () => {
-    const handler = nc()
+describe("use()", () => {
+  it("match all without base", async () => {
+    const handler = nc();
     handler.use((req, res, next) => {
-      req.ok = 'ok';
+      req.ok = "ok";
       next();
     });
     handler.get((req, res) => {
       res.end(req.ok);
     });
     const app = createServer(handler);
-    await request(app).get('/').expect('ok');
-    await request(app).get('/some/path').expect('ok');
+    await request(app).get("/").expect("ok");
+    await request(app).get("/some/path").expect("ok");
   });
 
-  it('match path by base', async () => {
-    const handler = nc()
-    handler.use('/this/that/', (req, res, next) => {
-      req.ok = 'ok';
+  it("match path by base", async () => {
+    const handler = nc();
+    handler.use("/this/that/", (req, res, next) => {
+      req.ok = "ok";
       next();
     });
     handler.get((req, res) => {
-      res.end(req.ok || 'no');
+      res.end(req.ok || "no");
     });
     const app = createServer(handler);
-    await request(app).get('/some/path').expect('no');
-    await request(app).get('/this/that/these/those').expect('ok');
+    await request(app).get("/some/path").expect("no");
+    await request(app).get("/this/that/these/those").expect("ok");
   });
 
-  it('mount subapp', () => {
+  it("mount subapp", () => {
     const handler2 = nc();
     handler2.use((req, res, next) => {
-      req.hello = 'world';
+      req.hello = "world";
       next();
     });
 
-    const handler = nc()
+    const handler = nc();
     handler.use(handler2);
     handler.use((req, res) => res.end(req.hello));
 
     const app = createServer(handler);
-    return request(app).get('/').expect('world');
+    return request(app).get("/").expect("world");
   });
 
-  it('mount subapp with base', async () => {
+  it("mount subapp with base", async () => {
     const handler2 = nc();
-    handler2.get('/foo', (req, res) => {
-      res.end('ok');
+    handler2.get("/foo", (req, res) => {
+      res.end("ok");
     });
-    const handler = nc()
-    handler.use('/sub', handler2);
+    const handler = nc();
+    handler.use("/sub", handler2);
     const app = createServer(handler);
-    await request(app).get('/sub/foo').expect('ok');
-    await request(app).get('/sub').expect(404);
-    await request(app).get('/foo').expect(404);
+    await request(app).get("/sub/foo").expect("ok");
+    await request(app).get("/sub").expect(404);
+    await request(app).get("/foo").expect(404);
   });
 });
 
-describe('handle()', () => {
-  it('response with default 404 on no match', () => {
-    const handler = nc()
+describe("handle()", () => {
+  it("response with default 404 on no match", () => {
+    const handler = nc();
     handler.post((req, res) => {
-      res.end('');
+      res.end("");
     });
 
     const app = createServer(handler);
-    return request(app).get('/').expect(404);
+    return request(app).get("/").expect(404);
   });
 
-  it('response with custom 404 on no match', () => {
+  it("response with custom 404 on no match", () => {
     function onNoMatch(req, res) {
-      res.end('');
+      res.end("");
     }
 
     const handler2 = nc({ onNoMatch });
     const app = createServer(handler2);
-    return request(app).get('/').expect(200);
+    return request(app).get("/").expect(200);
   });
 
-  it('call .find with pathname instead of url', () => {
-    const handler = nc().use('/test', (req, res) => res.end('ok'));
+  it("call .find with pathname instead of url", () => {
+    const handler = nc().use("/test", (req, res) => res.end("ok"));
     const app = createServer(handler);
-    return request(app).get('/test?p').expect('ok');
-  })
+    return request(app).get("/test?p").expect("ok");
+  });
 });
 
-describe('apply()', () => {
-  it('apply middleware to req and res', () => {
-    const handler = nc()
+describe("run()", () => {
+  it("run req and res through middleware", () => {
+    const handler = nc();
     handler.use((req, res, next) => {
-      req.hello = 'world';
+      req.hello = "world";
       next();
     });
     const app = createServer(async (req, res, next) => {
-      await handler.apply(req, res);
-      res.end(req.hello || '');
+      await handler.run(req, res);
+      res.end(req.hello || "");
     });
-    return request(app).get('/').expect('world');
+    return request(app).get("/").expect("world");
   });
 
-  it('reject if there is an error', () => {
-    const handler = nc()
+  it("reject if there is an error", () => {
+    const handler = nc();
     handler.use(() => {
-      throw new Error('error :(');
+      throw new Error("error :(");
     });
     const app = createServer(async (req, res, next) => {
       try {
-        await handler.apply(req, res);
-        res.end('good');
+        await handler.run(req, res);
+        res.end("good");
       } catch (e) {
         res.end(e.toString());
       }
     });
-    return request(app).get('/').expect('Error: error :(');
+    return request(app).get("/").expect("Error: error :(");
   });
 });
 
-describe('onError', () => {
-  it('default to onerror', () => {
-    const handler = nc()
+describe("onError", () => {
+  it("default to onerror", () => {
+    const handler = nc();
     handler.get((req, res) => {
-      throw new Error('error');
+      throw new Error("error");
     });
 
     const app = createServer(handler);
-    return request(app).get('/').expect(500).expect('error');
+    return request(app).get("/").expect(500).expect("error");
   });
 
-  it('use custom onError', async () => {
+  it("use custom onError", async () => {
     function onError(err, req, res, next) {
-      res.end('One does not simply ignore error');
+      res.end("One does not simply ignore error");
     }
     const handler2 = nc({ onError });
     handler2.use((req, res, next) => {
       next();
     });
     handler2.get((req, res, next) => {
-      throw new Error('wackk');
+      throw new Error("wackk");
     });
     const app = createServer(handler2);
     await request(app)
-      .get('/')
+      .get("/")
       .expect(200)
-      .expect('One does not simply ignore error');
+      .expect("One does not simply ignore error");
   });
 
-  it('continue chain with next', () => {
+  it("continue chain with next", () => {
     function onError(err, req, res, next) {
       next();
     }
@@ -283,12 +301,12 @@ describe('onError', () => {
       .get((req, res, next) => {
         throw new Error();
       })
-      .get((req, res) => res.end('no error'));
+      .get((req, res) => res.end("no error"));
     const app = createServer(handler2);
-    return request(app).get('/').expect('no error');
+    return request(app).get("/").expect("no error");
   });
 
-  it('catch async errors', () => {
+  it("catch async errors", () => {
     function onError(err, req, res, next) {
       res.end(err.message);
     }
@@ -297,10 +315,26 @@ describe('onError', () => {
       next();
     });
     handler2.use(async (req, res) => {
-      throw new Error('Something failed');
+      throw new Error("Something failed");
     });
-    handler2.get(async (req, res) => res.end('ok'));
+    handler2.get(async (req, res) => res.end("ok"));
     const app = createServer(handler2);
-    return request(app).get('/').expect('Something failed');
+    return request(app).get("/").expect("Something failed");
   });
 });
+
+describe("deprecate", () => {
+  it("apply() for run()", async () => {
+    const handler = nc();
+    handler.use((req, res, next) => {
+      req.hello = "world";
+      next();
+    });
+    const app = createServer(async (req, res, next) => {
+      await handler.apply(req, res);
+      res.end(req.hello || "");
+    });
+    return request(app).get("/").expect("world");
+  });
+})
+


### PR DESCRIPTION
`apply()` is replaced with `run()`.

It will be removed completely in `v1.0.0`.

Close #82 