### PR TITLE
Express Router compatibility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,5 +14,6 @@
         "ecmaVersion": 2018
     },
     "rules": {
+        "no-unexpected-multiline": "off"
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
         "ecmaVersion": 2018
     },
     "rules": {
-        "no-unexpected-multiline": "off"
+        "no-unexpected-multiline": "off",
+        "no-cond-assign": "off"
     }
 }

--- a/README.md
+++ b/README.md
@@ -178,14 +178,14 @@ handler.use(passport.initialize());
 `fn`(s) are functions of `(req, res[, next])`. This is ideal to be used in API Routes.
 
 ```javascript
-handler.use('/user', passport.initialize());
-handler.get('/user', (req, res, next) => {
+handler.use('/api/user', passport.initialize());
+handler.get('/api/user', (req, res, next) => {
   res.json(req.user);
 });
-handler.post('/users', (req, res, next) => {
+handler.post('/api/users', (req, res, next) => {
   res.end('User created');
 });
-handler.put('/user/:id', (req, res, next) => {
+handler.put('/api/user/:id', (req, res, next) => {
   // https://nextjs.org/docs/routing/dynamic-routes
   res.end(`User ${req.query.id} updated`);
 });
@@ -222,14 +222,35 @@ export async function getServerSideProps({ req, res }) {
     props: { user: req.user }
   };
 }
-
 ```
 
-
-
-
-
 ## Recipes
+
+### Next.js
+
+<details id="catch-all">
+<summary>Match multiple routes</summary>
+
+If you created the file `/api/<specific route>.js` folder, the handler will only run on that specific route. 
+
+If you need to create all handlers for all routes in one file (similar to `Express.js`). You can use [Optional catch all API routes](https://nextjs.org/docs/api-routes/dynamic-api-routes#optional-catch-all-api-routes).
+
+```js
+// pages/api/[[...slug]].js
+import nc from 'next-connect';
+
+const handler = nc({ attachParams: true })
+  .use("/api/hello", someMiddleware())
+  .get("/api/user/:userId", (req, res) => {
+    res.send(`Hello ${req.params.userId}`);
+  });
+
+export default handler;
+```
+
+While this allows quick migration from Express.js, consider seperating routes into different files (`/api/user/[userId].js`, `/api/hello.js`) in the future.
+
+</details>
 
 ### Using in other frameworks
 
@@ -277,7 +298,7 @@ module.exports = nc()
 
 ```javascript
 const http = require('http')
-// const http = require('http2)
+// const http = require('http2')
 const nc = require('next-connect')
 
 const handler = nc()
@@ -292,32 +313,6 @@ const handler = nc()
 
 http.createServer(handler).listen(PORT);
 ```
-
-</details>
-
-### Next.js
-
-<details id="catch-all">
-<summary>Match multiple routes</summary>
-
-If you created the file `/api/<specific route>.js` folder, the handler will only run on that specific route. 
-
-If you need to create all handlers for all routes in one file (similar to `Express.js`). You can use [Optional catch all API routes](https://nextjs.org/docs/api-routes/dynamic-api-routes#optional-catch-all-api-routes).
-
-```js
-// pages/api/[[...slug]].js
-import nc from 'next-connect';
-
-const handler = nc({ attachParams: true })
-  .use("/api/hello", someMiddleware())
-  .get("/api/user/:userId", (req, res) => {
-    res.send(`Hello ${req.params.userId}`);
-  });
-
-export default handler;
-```
-
-While this allows quick migration from Express.js, consider seperating routes into different files (`/api/user/[userId].js`, `/api/hello.js`) in the future.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -22,22 +22,22 @@ yarn add next-connect
 `next-connect` is often used in [API Routes](https://nextjs.org/docs/api-routes/introduction):
 
 ```javascript
-// pages/api/hello-world.js
-import nc from 'next-connect';
+// pages/api/hello.js
+import nc from "next-connect";
 
 const handler = nc()
   .use(someMiddleware())
   .get((req, res) => {
-    res.send('Hello world');
+    res.send("Hello world");
   })
   .post((req, res) => {
-    res.json({ hello: 'world' });
+    res.json({ hello: "world" });
   })
   .put(async (req, res) => {
-    res.end('async/await is also supported!');
+    res.end("async/await is also supported!");
   })
   .patch(async (req, res) => {
-    throw new Error('Throws me around! Error can be caught and handled.')
+    throw new Error("Throws me around! Error can be caught and handled.");
   });
 
 export default handler;
@@ -54,29 +54,33 @@ See an example in [nextjs-mongodb-app](https://github.com/hoangvvo/nextjs-mongod
 By default, the base interfaces of `req` and `res` are `IncomingMessage` and `ServerResponse`. When using in API Routes, you would set them to `NextApiRequest` and `NextApiResponse` by providing the generics to the factory function like so:
 
 ```typescript
-import { NextApiRequest, NextApiResponse } from 'next';
-import nc from 'next-connect';
+import { NextApiRequest, NextApiResponse } from "next";
+import nc from "next-connect";
 
-const handler = nc<NextApiRequest, NextApiResponse>()
+const handler = nc<NextApiRequest, NextApiResponse>();
 ```
 
 In each handler, you can also define custom properties to `req` and `res` (such as `req.user` or `res.cookie`) like so:
 
 ```typescript
-interface ExtendedRequest { user: string };
-interface ExtendedResponse { cookie: (name: string, value: string) => void };
+interface ExtendedRequest {
+  user: string;
+}
+interface ExtendedResponse {
+  cookie(name: string, value: string): void;
+}
 
 handler.post<ExtendedRequest, ExtendedResponse>((req, res) => {
-  req.user = 'Anakin';
-  res.cookie('sid', '8108');
-})
+  req.user = "Anakin";
+  res.cookie("sid", "8108");
+});
 ```
 
 ## API
 
 The API is similar to [Express.js](https://github.com/expressjs/express) with several differences:
 
-- It does not include any [helper methods](http://expressjs.com/en/4x/api.html#res.append) or template engine (you can incorporate them using middleware)
+- It does not include any [helper methods](http://expressjs.com/en/4x/api.html#res.append) or template engine (you can incorporate them using middleware).
 - It does not suppoprt error-handling middleware pattern. Use `options.onError` instead.
 
 It is more like good ol' [connect](https://www.npmjs.com/package/connect) (hence the name) with method routing.
@@ -96,20 +100,20 @@ function onError(err, req, res, next) {
 
   res.status(500).end(err.toString());
   // OR: you may want to continue
-  next()
+  next();
 }
 
 const handler = nc({ onError });
 
 handler
   .use((req, res, next) => {
-    throw new Error('oh no!');
+    throw new Error("oh no!");
     // or use next
-    next(Error('oh no'));
+    next(Error("oh no"));
   })
   .use((req, res) => {
     // this will run if next() is called in onError
-    res.end('error no more');
+    res.end("error no more");
   });
 ```
 
@@ -120,7 +124,7 @@ By default, it responses with `404` status and `not found` body.
 
 ```javascript
 function onNoMatch(req, res) {
-  res.status(404).end('page is not found... or is it')
+  res.status(404).end("page is not found... or is it");
 }
 
 const handler = nc({ onNoMatch });
@@ -128,16 +132,15 @@ const handler = nc({ onNoMatch });
 
 #### options.attachParams
 
-Passing `true` will attach `params` object to `req`. By default, it does not set `req.params`.
+Passing `true` will attach `params` object to `req`. By default, it does not set to `req.params`.
 
 ```javascript
 const handler = nc({ attachParams: true });
 
 handler.get("/users/:userId/posts/:postId", (req, res) => {
+  // Visiting '/users/12/posts/23' will render '{"userId":"12","postId":"23"}'
   res.send(req.params);
 });
-
-// Visiting '/users/12/posts/23' will render '{"userId": "12","postId":"23"}'
 ```
 
 ### .use(base, ...fn)
@@ -149,21 +152,26 @@ handler.get("/users/:userId/posts/:postId", (req, res) => {
 ```javascript
 // Mount a middleware function
 handler.use((req, res, next) => {
-  req.hello = 'world';
-  // call next if you want to proceed to next in chain
-  next();
+  req.hello = "world";
+  next(); // call to proceed to next in chain
 });
+
 // Or include a base
-handler.use('/foo', fn); // Only run in /foo/**
+handler.use("/foo", fn); // Only run in /foo/**
 
 // Mount an instance of next-connect
-const common = nc().use(midd1).use(midd2); // You may have some common middleware to be used in every route.
-const auth = nc().use('/dashboard', checkAuth);
-const subapp = nc().get(getHandle).post('/baz', postHandle);
+const common = nc().use(midd1).use("/", midd2); // good for common middlewares
+const auth = nc().use("/dashboard", checkAuth);
+const subapp = nc().get(getHandle).post("/baz", postHandle).put("/", putHandle);
 handler
-  .use(common) // `midd1` and `midd2` runs everywhere
-  .use(auth) // `checkAuth` runs on /dashboard/*
-  .use('/foo', subapp); // `getHandle` runs on /foo while `postHandle` runs on /foo/baz
+  // `midd1` and `midd2` runs everywhere
+  .use(common)
+  // `checkAuth` only runs on /dashboard/*
+  .use(auth)
+  // `getHandle` runs on /foo/*
+  // `postHandle` runs on /foo/baz
+  // `putHandle` runs on /foo
+  .use("/foo", subapp);
 
 // You can use a library too.
 handler.use(passport.initialize());
@@ -178,20 +186,19 @@ handler.use(passport.initialize());
 `fn`(s) are functions of `(req, res[, next])`. This is ideal to be used in API Routes.
 
 ```javascript
-handler.use('/api/user', passport.initialize());
-handler.get('/api/user', (req, res, next) => {
+handler.get("/api/user", (req, res, next) => {
   res.json(req.user);
 });
-handler.post('/api/users', (req, res, next) => {
-  res.end('User created');
+handler.post("/api/users", (req, res, next) => {
+  res.end("User created");
 });
-handler.put('/api/user/:id', (req, res, next) => {
+handler.put("/api/user/:id", (req, res, next) => {
   // https://nextjs.org/docs/routing/dynamic-routes
   res.end(`User ${req.query.id} updated`);
 });
 handler.get((req, res, next) => {
-  res.end('This matches whatever route')
-})
+  res.end("This matches whatever route");
+});
 ```
 
 However, since Next.js already handles routing (including dynamic routes), we often omit `pattern` in `.METHOD`.
@@ -209,9 +216,7 @@ This can be useful in [`getServerSideProps`](https://nextjs.org/docs/basic-featu
 ```javascript
 // page/index.js
 export async function getServerSideProps({ req, res }) {
-  const handler = nc()
-    .use(passport.initialize())
-    .post(postMiddleware);
+  const handler = nc().use(passport.initialize()).post(postMiddleware);
   try {
     await handler.run(req, res);
   } catch (e) {
@@ -219,7 +224,7 @@ export async function getServerSideProps({ req, res }) {
   }
   // do something with the upgraded req and res
   return {
-    props: { user: req.user }
+    props: { user: req.user },
   };
 }
 ```
@@ -237,7 +242,7 @@ If you need to create all handlers for all routes in one file (similar to `Expre
 
 ```js
 // pages/api/[[...slug]].js
-import nc from 'next-connect';
+import nc from "next-connect";
 
 const handler = nc({ attachParams: true })
   .use("/api/hello", someMiddleware())
@@ -260,16 +265,16 @@ While this allows quick migration from Express.js, consider seperating routes in
 <summary><a href="https://github.com/zeit/micro">Micro</a></summary>
 
 ```javascript
-const {send} = require('micro')
-const nc = require('next-connect')
+const { send } = require("micro");
+const nc = require("next-connect");
 
 module.exports = nc()
   .use(middleware)
   .get((req, res) => {
-    res.end('Hello World!')
+    res.end("Hello World!");
   })
   .post((req, res) => {
-    send(res, 200, { hello: 'world' })
+    send(res, 200, { hello: "world" });
   });
 ```
 
@@ -279,15 +284,15 @@ module.exports = nc()
 <summary><a href="https://vercel.com/docs/serverless-functions/introduction">Vercel</a></summary>
 
 ```javascript
-const nc = require('next-connect')
+const nc = require("next-connect");
 
 module.exports = nc()
   .use(middleware)
   .get((req, res) => {
-    res.send('Hello World!')
+    res.send("Hello World!");
   })
   .post((req, res) => {
-    res.json({ hello: 'world' })
+    res.json({ hello: "world" });
   });
 ```
 
@@ -297,21 +302,22 @@ module.exports = nc()
 <summary>Node.js <a href="https://nodejs.org/api/http.html">HTTP</a> / <a href="https://nodejs.org/api/http2.html">HTTP2</a> Server</summary>
 
 ```javascript
-const http = require('http')
-// const http = require('http2')
-const nc = require('next-connect')
+const http = require("http");
+// const http2 = require('http2');
+const nc = require("next-connect");
 
 const handler = nc()
   .use(middleware)
   .get((req, res) => {
-    res.end('Hello world');
+    res.end("Hello world");
   })
   .post((req, res) => {
-    res.setHeader('content-type', 'application/json');
-    res.end(JSON.stringify({ hello: 'world' }));
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ hello: "world" }));
   });
 
 http.createServer(handler).listen(PORT);
+// http2.createServer(handler).listen(PORT);
 ```
 
 </details>

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -28,6 +28,8 @@ declare module "next-connect" {
   ): Promise<void>;
 
   interface NextConnect<U, V> {
+    mouthpath: string;
+
     use<T = {}, S = {}>(...handlers: Middleware<U & T, V & S>[]): this;
     use<T = {}, S = {}>(pattern: string | RegExp, ...handlers: Middleware<U & T, V & S>[]): this;
 
@@ -59,8 +61,6 @@ declare module "next-connect" {
     patch<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
 
     run(req: U, res: V): Promise<void>;
-    /** @deprecated */
-    apply(req: U, res: V): Promise<void>;
 
     handle(req: U, res: V, done: NextHandler): void;
   }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -29,8 +29,6 @@ declare module "next-connect" {
   ): Promise<void>;
 
   interface NextConnect<U, V> {
-    mouthpath: string;
-
     use<T = {}, S = {}>(...handlers: Middleware<U & T, V & S>[]): this;
     use<T = {}, S = {}>(pattern: string | RegExp, ...handlers: Middleware<U & T, V & S>[]): this;
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,46 +23,75 @@ declare module "next-connect" {
     attachParams?: boolean;
   }
 
-  function NextConnect<U, V>(
-    req: U,
-    res: V
-  ): Promise<void>;
+  function NextConnect<U, V>(req: U, res: V): Promise<void>;
 
   interface NextConnect<U, V> {
     use<T = {}, S = {}>(...handlers: Middleware<U & T, V & S>[]): this;
-    use<T = {}, S = {}>(pattern: string | RegExp, ...handlers: Middleware<U & T, V & S>[]): this;
+    use<T = {}, S = {}>(
+      pattern: string | RegExp,
+      ...handlers: Middleware<U & T, V & S>[]
+    ): this;
 
     all<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
-    all<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
+    all<T = {}, S = {}>(
+      pattern: string | RegExp,
+      ...handlers: RequestHandler<U & T, V & S>[]
+    ): this;
 
     get<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
-    get<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
+    get<T = {}, S = {}>(
+      pattern: string | RegExp,
+      ...handlers: RequestHandler<U & T, V & S>[]
+    ): this;
 
     head<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
-    head<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
+    head<T = {}, S = {}>(
+      pattern: string | RegExp,
+      ...handlers: RequestHandler<U & T, V & S>[]
+    ): this;
 
     post<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
-    post<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
+    post<T = {}, S = {}>(
+      pattern: string | RegExp,
+      ...handlers: RequestHandler<U & T, V & S>[]
+    ): this;
 
     put<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
-    put<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
+    put<T = {}, S = {}>(
+      pattern: string | RegExp,
+      ...handlers: RequestHandler<U & T, V & S>[]
+    ): this;
 
     delete<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
-    delete<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
+    delete<T = {}, S = {}>(
+      pattern: string | RegExp,
+      ...handlers: RequestHandler<U & T, V & S>[]
+    ): this;
 
     options<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
-    options<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
+    options<T = {}, S = {}>(
+      pattern: string | RegExp,
+      ...handlers: RequestHandler<U & T, V & S>[]
+    ): this;
 
     trace<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
-    trace<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
+    trace<T = {}, S = {}>(
+      pattern: string | RegExp,
+      ...handlers: RequestHandler<U & T, V & S>[]
+    ): this;
 
     patch<T = {}, S = {}>(...handlers: RequestHandler<U & T, V & S>[]): this;
-    patch<T = {}, S = {}>(pattern: string | RegExp, ...handlers: RequestHandler<U & T, V & S>[]): this;
+    patch<T = {}, S = {}>(
+      pattern: string | RegExp,
+      ...handlers: RequestHandler<U & T, V & S>[]
+    ): this;
 
     run(req: U, res: V): Promise<void>;
 
     handle(req: U, res: V, done: NextHandler): void;
   }
 
-  export default function <T = IncomingMessage, S = ServerResponse>(options?: Options<T, S>): NextConnect<T, S>;
+  export default function <T = IncomingMessage, S = ServerResponse>(
+    options?: Options<T, S>
+  ): NextConnect<T, S>;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -20,6 +20,7 @@ declare module "next-connect" {
   interface Options<T, S> {
     onError?: ErrorHandler<T, S>;
     onNoMatch?: RequestHandler<T, S>;
+    attachParams?: boolean;
   }
 
   function NextConnect<U, V>(

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const isResSent = (res) => res.finished || res.headersSent || res.writableEnded;
 module.exports = ({
   onError = onerror,
   onNoMatch = onerror.bind(null, { code: 404, message: "not found" }),
-  attachParams = false
+  attachParams = false,
 } = {}) => {
   function nc(req, res) {
     return nc.run(req, res).then(
@@ -19,7 +19,6 @@ module.exports = ({
     );
   }
   nc.routes = [];
-  nc.mountpath = "/";
   const _use = Trouter.prototype.use.bind(nc);
   const _find = Trouter.prototype.find.bind(nc);
   const _add = Trouter.prototype.add.bind(nc);
@@ -30,8 +29,15 @@ module.exports = ({
   }
   nc.use = function use(base, ...fns) {
     if (typeof base !== "string") return this.use("/", base, ...fns);
-    const mount = (fn) =>
-      fn.routes ? (fn.mountpath = base) && fn.handle.bind(fn) : fn;
+    if (base !== "/") {
+      fns.unshift((req, _, next) => {
+        req.url = req.url.substring(base.length);
+        if (req.url[0] !== "/") req.url = "/" + req.url;
+        next();
+      });
+      fns.push((req, _, next) => (req.url = base + req.url) && next());
+    }
+    const mount = (fn) => (fn.routes ? fn.handle.bind(fn) : fn);
     _use(base, ...fns.map(mount));
     return nc;
   };
@@ -51,12 +57,9 @@ module.exports = ({
   };
   nc.handle = function handle(req, res, done) {
     const idx = req.url.indexOf("?");
-    const pathname = idx !== -1 ? req.url.substring(0, idx) : req.url;
     const { handlers, params } = _find(
       req.method,
-      this.mountpath !== "/"
-        ? pathname.substring(this.mountpath.length)
-        : pathname
+      idx !== -1 ? req.url.substring(0, idx) : req.url
     );
     if (attachParams) req.params = params;
     let i = 0;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,15 @@
 const Trouter = require("trouter");
 
 function onerror(err, req, res) {
-  res.statusCode = err.code || err.status || 500;
-  res.end(err.message || res.statusCode.toString());
+  res.statusCode = err.status || 500;
+  res.end(err.message);
 }
 
 const isResSent = (res) => res.finished || res.headersSent || res.writableEnded;
 
 module.exports = ({
   onError = onerror,
-  onNoMatch = onerror.bind(null, { code: 404, message: "not found" }),
+  onNoMatch = onerror.bind(null, { status: 404, message: "not found" }),
   attachParams = false,
 } = {}) => {
   function nc(req, res) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 const Trouter = require("trouter");
-const { deprecate } = require("util");
 
 function onerror(err, req, res) {
   res.statusCode = err.code || err.status || 500;
@@ -7,7 +6,6 @@ function onerror(err, req, res) {
 }
 
 const isResSent = (res) => res.finished || res.headersSent || res.writableEnded;
-const mount = (fn) => (fn.routes ? fn.handle.bind(fn) : fn);
 
 module.exports = ({
   onError = onerror,
@@ -19,11 +17,11 @@ module.exports = ({
       (err) => onError(err, req, res)
     );
   }
-  const router = new Trouter();
   nc.routes = [];
-  function add(...args) {
-    if (typeof args[1] !== "string") args.splice(1, 0, "*");
-    router.add.apply(nc, args);
+  nc.mountpath = "/";
+  function add(method, base, ...fns) {
+    if (typeof base !== "string") return add(method, "*", base, ...fns);
+    Trouter.prototype.add.call(nc, method, base, ...fns);
     return nc;
   }
   nc.all = add.bind(nc, "");
@@ -36,30 +34,34 @@ module.exports = ({
   nc.trace = add.bind(nc, "TRACE");
   nc.patch = add.bind(nc, "PATCH");
   nc.use = function use(base, ...fns) {
-    if (typeof base === "string") {
-      router.use.apply(nc, [
-        base,
-        fns.map((fn) => {
-          fn.baseUrl = base;
-          return mount(fn);
-        }),
-      ]);
-    } else router.use.apply(nc, ["/", [base, ...fns].map(mount)]);
+    if (typeof base !== "string") return this.use("/", base, ...fns);
+    Trouter.prototype.use.call(
+      nc,
+      base,
+      ...fns.map((fn) => {
+        if (fn.routes) {
+          fn.mountpath = base;
+          return fn.handle.bind(fn);
+        }
+        return fn;
+      })
+    );
     return nc;
   };
-  nc.find = router.find.bind(nc);
   nc.run = function run(req, res) {
     return new Promise((resolve, reject) => {
       this.handle(req, res, (err) => (err ? reject(err) : resolve()));
     });
   };
-  nc.apply = deprecate(nc.run, "next-connect: apply() is deprecated. Use run() instead.");
+  const find = Trouter.prototype.find.bind(nc);
   nc.handle = function handle(req, res, done) {
     const idx = req.url.indexOf("?");
     const pathname = idx !== -1 ? req.url.substring(0, idx) : req.url;
-    const { handlers } = this.find(
+    const { handlers } = find(
       req.method,
-      this.baseUrl ? pathname.substring(this.baseUrl.length) : pathname
+      this.mountpath !== "/"
+        ? pathname.substring(this.mountpath.length)
+        : pathname
     );
     let i = 0;
     const len = handlers.length;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ const isResSent = (res) => res.finished || res.headersSent || res.writableEnded;
 module.exports = ({
   onError = onerror,
   onNoMatch = onerror.bind(null, { code: 404, message: "not found" }),
+  attachParams = false
 } = {}) => {
   function nc(req, res) {
     return nc.run(req, res).then(
@@ -51,12 +52,13 @@ module.exports = ({
   nc.handle = function handle(req, res, done) {
     const idx = req.url.indexOf("?");
     const pathname = idx !== -1 ? req.url.substring(0, idx) : req.url;
-    const { handlers } = _find(
+    const { handlers, params } = _find(
       req.method,
       this.mountpath !== "/"
         ? pathname.substring(this.mountpath.length)
         : pathname
     );
+    if (attachParams) req.params = params;
     let i = 0;
     const len = handlers.length;
     const loop = async (next) => handlers[i++](req, res, next);

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,12 +30,17 @@ module.exports = ({
   nc.use = function use(base, ...fns) {
     if (typeof base !== "string") return this.use("/", base, ...fns);
     if (base !== "/") {
+      let slashAdded = false;
       fns.unshift((req, _, next) => {
         req.url = req.url.substring(base.length);
-        if (req.url[0] !== "/") req.url = "/" + req.url;
+        if ((slashAdded = req.url[0] !== "/")) req.url = "/" + req.url;
         next();
       });
-      fns.push((req, _, next) => (req.url = base + req.url) && next());
+      fns.push(
+        (req, _, next) =>
+          (req.url = base + (slashAdded ? req.url.substring(1) : req.url)) &&
+          next()
+      );
     }
     const mount = (fn) => (fn.routes ? fn.handle.bind(fn) : fn);
     _use(base, ...fns.map(mount));

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,11 +19,21 @@ module.exports = ({
   }
   nc.routes = [];
   nc.mountpath = "/";
+  const _use = Trouter.prototype.use.bind(nc);
+  const _find = Trouter.prototype.find.bind(nc);
+  const _add = Trouter.prototype.add.bind(nc);
   function add(method, base, ...fns) {
     if (typeof base !== "string") return add(method, "*", base, ...fns);
-    Trouter.prototype.add.call(nc, method, base, ...fns);
+    _add(method, base, ...fns);
     return nc;
   }
+  nc.use = function use(base, ...fns) {
+    if (typeof base !== "string") return this.use("/", base, ...fns);
+    const mount = (fn) =>
+      fn.routes ? (fn.mountpath = base) && fn.handle.bind(fn) : fn;
+    _use(base, ...fns.map(mount));
+    return nc;
+  };
   nc.all = add.bind(nc, "");
   nc.get = add.bind(nc, "GET");
   nc.head = add.bind(nc, "HEAD");
@@ -33,31 +43,15 @@ module.exports = ({
   nc.options = add.bind(nc, "OPTIONS");
   nc.trace = add.bind(nc, "TRACE");
   nc.patch = add.bind(nc, "PATCH");
-  nc.use = function use(base, ...fns) {
-    if (typeof base !== "string") return this.use("/", base, ...fns);
-    Trouter.prototype.use.call(
-      nc,
-      base,
-      ...fns.map((fn) => {
-        if (fn.routes) {
-          fn.mountpath = base;
-          return fn.handle.bind(fn);
-        }
-        return fn;
-      })
-    );
-    return nc;
-  };
   nc.run = function run(req, res) {
     return new Promise((resolve, reject) => {
       this.handle(req, res, (err) => (err ? reject(err) : resolve()));
     });
   };
-  const find = Trouter.prototype.find.bind(nc);
   nc.handle = function handle(req, res, done) {
     const idx = req.url.indexOf("?");
     const pathname = idx !== -1 ? req.url.substring(0, idx) : req.url;
-    const { handlers } = find(
+    const { handlers } = _find(
       req.method,
       this.mountpath !== "/"
         ? pathname.substring(this.mountpath.length)
@@ -65,16 +59,14 @@ module.exports = ({
     );
     let i = 0;
     const len = handlers.length;
+    const loop = async (next) => handlers[i++](req, res, next);
     const next = (err) => {
       i < len
         ? err
           ? onError(err, req, res, next)
-          : loop().catch(next)
+          : loop(next).catch(next)
         : done && done(err);
     };
-    async function loop() {
-      return handlers[i++](req, res, next);
-    }
     next();
   };
   return nc;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -201,6 +201,28 @@ describe("use()", () => {
     await request(app).get("/sub").expect(404);
     await request(app).get("/foo").expect(404);
   });
+
+  it("strip base from req.url", async () => {
+    const handler2 = nc();
+    handler2.get("/foo", (req, res) => {
+      res.end(req.url);
+    });
+    const handler = nc();
+    handler.use("/sub", handler2);
+    const app = createServer(handler);
+    await request(app).get("/sub/foo").expect("/foo");
+  })
+
+  it("req.url must starts with slash after strip base", async () => {
+    const handler2 = nc();
+    handler2.get((req, res) => {
+      res.end(req.url);
+    });
+    const handler = nc();
+    handler.use("/sub", handler2);
+    const app = createServer(handler);
+    await request(app).get("/sub").expect("/");
+  })
 });
 
 describe("handle()", () => {
@@ -225,7 +247,7 @@ describe("handle()", () => {
   });
 
   it("call .find with pathname instead of url", () => {
-    const handler = nc().use("/test", (req, res) => res.end("ok"));
+    const handler = nc().get("/test", (req, res) => res.end("ok"));
     const app = createServer(handler);
     return request(app).get("/test?p").expect("ok");
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -322,19 +322,3 @@ describe("onError", () => {
     return request(app).get("/").expect("Something failed");
   });
 });
-
-describe("deprecate", () => {
-  it("apply() for run()", async () => {
-    const handler = nc();
-    handler.use((req, res, next) => {
-      req.hello = "world";
-      next();
-    });
-    const app = createServer(async (req, res, next) => {
-      await handler.apply(req, res);
-      res.end(req.hello || "");
-    });
-    return request(app).get("/").expect("world");
-  });
-})
-

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -301,14 +301,20 @@ describe("run()", () => {
 });
 
 describe("onError", () => {
-  it("default to onerror", () => {
+  it("default to onerror", async () => {
     const handler = nc();
     handler.get((req, res) => {
       throw new Error("error");
     });
+    handler.post((req, res) => {
+      const err = new Error();
+      err.status = 401;
+      throw err;
+    })
 
     const app = createServer(handler);
-    return request(app).get("/").expect(500).expect("error");
+    await request(app).get("/").expect(500).expect("error");
+    await request(app).post("/").expect(401).expect(""); // default to err.status
   });
 
   it("use custom onError", async () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -211,7 +211,7 @@ describe("use()", () => {
     handler.use("/sub", handler2);
     const app = createServer(handler);
     await request(app).get("/sub/foo").expect("/foo");
-  })
+  });
 
   it("req.url must starts with slash after strip base", async () => {
     const handler2 = nc();
@@ -222,7 +222,7 @@ describe("use()", () => {
     handler.use("/sub", handler2);
     const app = createServer(handler);
     await request(app).get("/sub").expect("/");
-  })
+  });
 
   it("req.url is back to original after subapp", async () => {
     const handler2 = nc();
@@ -233,12 +233,12 @@ describe("use()", () => {
     handler.use("/sub", handler2);
     handler.get((req, res) => {
       res.end(req.url);
-    })
+    });
     const app = createServer(handler);
     await request(app).get("/sub/foo").expect("/sub/foo");
     // undo added slash
     await request(app).get("/sub?").expect("/sub?");
-  })
+  });
 });
 
 describe("handle()", () => {
@@ -362,17 +362,20 @@ describe("onError", () => {
 });
 
 describe("req.params", () => {
-  const addParamsRoute = (ncInstance) => ncInstance.get("/:userId", (req, res) => {
-    res.end(""+JSON.stringify(req.params));
-  });
+  const addParamsRoute = (ncInstance) =>
+    ncInstance.get("/:userId", (req, res) => {
+      res.end("" + JSON.stringify(req.params));
+    });
+
   it("is undefined if attachParams is falsy", async () => {
     const handler = addParamsRoute(nc());
-    await request(createServer(handler)).get("/1").expect('undefined');
+    await request(createServer(handler)).get("/1").expect("undefined");
     const handler2 = addParamsRoute(nc({ attachParams: false }));
-    await request(createServer(handler2)).get("/1").expect('undefined');
+    await request(createServer(handler2)).get("/1").expect("undefined");
   });
+
   it("is params object if attachParams is true", () => {
     const handler = addParamsRoute(nc({ attachParams: true }));
     return request(createServer(handler)).get("/1").expect('{"userId":"1"}');
-  })
-})
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -223,6 +223,22 @@ describe("use()", () => {
     const app = createServer(handler);
     await request(app).get("/sub").expect("/");
   })
+
+  it("req.url is back to original after subapp", async () => {
+    const handler2 = nc();
+    handler2.get((req, res, next) => {
+      next();
+    });
+    const handler = nc();
+    handler.use("/sub", handler2);
+    handler.get((req, res) => {
+      res.end(req.url);
+    })
+    const app = createServer(handler);
+    await request(app).get("/sub/foo").expect("/sub/foo");
+    // undo added slash
+    await request(app).get("/sub?").expect("/sub?");
+  })
 });
 
 describe("handle()", () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -322,3 +322,19 @@ describe("onError", () => {
     return request(app).get("/").expect("Something failed");
   });
 });
+
+describe("req.params", () => {
+  const addParamsRoute = (ncInstance) => ncInstance.get("/:userId", (req, res) => {
+    res.end(""+JSON.stringify(req.params));
+  });
+  it("is undefined if attachParams is falsy", async () => {
+    const handler = addParamsRoute(nc());
+    await request(createServer(handler)).get("/1").expect('undefined');
+    const handler2 = addParamsRoute(nc({ attachParams: false }));
+    await request(createServer(handler2)).get("/1").expect('undefined');
+  });
+  it("is params object if attachParams is true", () => {
+    const handler = addParamsRoute(nc({ attachParams: true }));
+    return request(createServer(handler)).get("/1").expect('{"userId":"1"}');
+  })
+})


### PR DESCRIPTION
This allows next-connect to consume Router created by `express`. To do so, we strip base from req.url (breaking) for subapp. Previously we do not mutate req.url so express router is not aware of the baseUrl. (Fix #121)

Also add an option to set `req.params` and some docs. (Fix #110)

We also remove the deprecated apply() function