### PR TITLE
Make NextConnect compatible with NextApiHandler

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,9 +23,9 @@ declare module "next-connect" {
     attachParams?: boolean;
   }
 
-  function NextConnect<U, V>(req: U, res: V): Promise<void>;
-
   interface NextConnect<U, V> {
+    (req: U, res: V): Promise<void>;
+
     use<T = {}, S = {}>(...handlers: Middleware<U & T, V & S>[]): this;
     use<T = {}, S = {}>(
       pattern: string | RegExp,


### PR DESCRIPTION
The following code was causing TS error because NextConnect was not compatible with NextApiHandler. It can be problematic when passing handler to functions which take NextApiHandler. This PR is to fix the issue.

```ts
import { NextApiRequest, NextApiResponse, NextApiHandler } from "next";
import nc, { NextConnect } from "next-connect";

// TS Error because NextConnect is not compatible with NextApiHandler
const handler: NextApiHandler = nc<NextApiRequest, NextApiResponse>();
```