### PR TITLE
Export the options interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,7 +17,7 @@ declare module "next-connect" {
     next: NextHandler
   ) => any | Promise<any>;
 
-  interface Options<Req, Res> {
+  export interface Options<Req, Res> {
     onError?: ErrorHandler<Req, Res>;
     onNoMatch?: RequestHandler<Req, Res>;
     attachParams?: boolean;


### PR DESCRIPTION
This allows for writing a wrapper around the factory function to e.g. always pass the `NextApiRequest` and `NextApiResponse` generics to the factory function.
I am now unable to type the options object which I would like to pass to the factory function.
Example: 
```typescript
function nextConnectApi<
  T = any,
  Req = NextApiRequest,
  Res = NextApiResponse<T>
>(options?: Options<Req, Res>) {
  return nc<Req, Res>(options);
}
```