### PR TITLE
fix(#161): use() accepts array

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,6 +34,9 @@ declare module "next-connect" {
     (req: Req, res: Res): Promise<void>;
 
     use<ReqExt = {}, ResExt = {}>(
+      handlers: Middleware<Req & ReqExt, Res & ResExt>[]
+    ): this;
+    use<ReqExt = {}, ResExt = {}>(
       ...handlers: Middleware<Req & ReqExt, Res & ResExt>[]
     ): this;
     use<ReqExt = {}, ResExt = {}>(

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ export default function factory({
     return nc;
   }
   nc.use = function use(base, ...fns) {
+    if (Array.isArray(base)) return this.use("/", ...base);
     if (typeof base === "function") return this.use("/", base, ...fns);
     if (typeof base === "string" && base !== "/") {
       let slashAdded = false;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -294,6 +294,22 @@ describe("use()", () => {
     await request(app).get("/some/path").expect("no");
   });
 
+  it("use accepts an array of middleware", async () => {
+    const handler = nc();
+    handler.use([(req, res, next) => {
+      req.ok1 = "ok1";
+      next();
+    },(req, res, next) => {
+      req.ok2 = "ok2";
+      next();
+    }]);
+    handler.get((req, res) => {
+      res.end(`${req.ok1}-${req.ok2}` || "no");
+    });
+    const app = createServer(handler);
+    await request(app).get("/some/path").expect("ok1-ok2");
+  });
+
   it("mount subapp", () => {
     const handler2 = nc();
     handler2.use((req, res, next) => {


### PR DESCRIPTION
This should allow `use()` to behave more like express.use