### PR TITLE
Complete handler chain if res is sent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,9 @@ export default function factory({
     if (attachParams) req.params = params;
     let i = 0;
     const len = handlers.length;
-    const loop = async (next) => handlers[i++](req, res, next);
+    const loop = async (next) => Promise.resolve(handlers[i++](req, res, next))
+      .then(() => isResSent(res) && done())
+      .catch(next);
     const next = (err) => {
       i < len
         ? err

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export default function factory({
     const len = handlers.length;
     const loop = async (next) => {
       try {
-        await Promise.resolve(handlers[i++](req, res, next)); 
+        await handlers[i++](req, res, next);
         isResSent(res) && done();
       } catch (err) {
         next(err);

--- a/src/index.js
+++ b/src/index.js
@@ -67,9 +67,14 @@ export default function factory({
     if (attachParams) req.params = params;
     let i = 0;
     const len = handlers.length;
-    const loop = async (next) => Promise.resolve(handlers[i++](req, res, next))
-      .then(() => isResSent(res) && done())
-      .catch(next);
+    const loop = async (next) => {
+      try {
+        await Promise.resolve(handlers[i++](req, res, next)); 
+        isResSent(res) && done();
+      } catch (err) {
+        next(err);
+      }
+    }
     const next = (err) => {
       i < len
         ? err


### PR DESCRIPTION
This change allows `handler(res, req)` to resolve for middlewares that don't call next, but end the response.

Example:

```js
// index.page.js
const handler = nc()
  .get(async (req, res) => {
    res.status(200).send('hello!')
  });
export default handler;
```

```js
import { createMocks } from 'node-mocks-http';
import handler from './index.page';

const { req, res } = createMocks({ method: 'GET', url: '/' });
await handler(req, res);
// With this change we can now get here.
```