### PR TITLE
Improve NextConnect method Types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,84 +25,84 @@ declare module "next-connect" {
   interface NextConnect<Req, Res> {
     (req: Req, res: Res): Promise<void>;
 
-    use<ReqExt = {}, ResExt = {}>(
-      ...handlers: Middleware<Req & ReqExt, Res & ResExt>[]
+    use<ReqExt extends Req = Req, ResExt extends Res = Res>(
+      ...handlers: Middleware<ReqExt, ResExt>[]
     ): this;
-    use<ReqExt = {}, ResExt = {}>(
+    use<ReqExt extends Req = Req, ResExt extends Res = Res>(
       pattern: string | RegExp,
-      ...handlers: Middleware<Req & ReqExt, Res & ResExt>[]
+      ...handlers: Middleware<ReqExt, ResExt>[]
     ): this;
 
-    all<ReqExt = {}, ResExt = {}>(
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+    all<ReqExt extends Req = Req, ResExt extends Res = Res>(
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
-    all<ReqExt = {}, ResExt = {}>(
+    all<ReqExt extends Req = Req, ResExt extends Res = Res>(
       pattern: string | RegExp,
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
 
-    get<ReqExt = {}, ResExt = {}>(
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+    get<ReqExt extends Req = Req, ResExt extends Res = Res>(
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
-    get<ReqExt = {}, ResExt = {}>(
+    get<ReqExt extends Req = Req, ResExt extends Res = Res>(
       pattern: string | RegExp,
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
 
-    head<ReqExt = {}, ResExt = {}>(
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+    head<ReqExt extends Req = Req, ResExt extends Res = Res>(
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
-    head<ReqExt = {}, ResExt = {}>(
+    head<ReqExt extends Req = Req, ResExt extends Res = Res>(
       pattern: string | RegExp,
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
 
-    post<ReqExt = {}, ResExt = {}>(
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+    post<ReqExt extends Req = Req, ResExt extends Res = Res>(
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
-    post<ReqExt = {}, ResExt = {}>(
+    post<ReqExt extends Req = Req, ResExt extends Res = Res>(
       pattern: string | RegExp,
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
 
-    put<ReqExt = {}, ResExt = {}>(
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+    put<ReqExt extends Req = Req, ResExt extends Res = Res>(
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
-    put<ReqExt = {}, ResExt = {}>(
+    put<ReqExt extends Req = Req, ResExt extends Res = Res>(
       pattern: string | RegExp,
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
 
-    delete<ReqExt = {}, ResExt = {}>(
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+    delete<ReqExt extends Req = Req, ResExt extends Res = Res>(
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
-    delete<ReqExt = {}, ResExt = {}>(
+    delete<ReqExt extends Req = Req, ResExt extends Res = Res>(
       pattern: string | RegExp,
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
 
-    options<ReqExt = {}, ResExt = {}>(
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+    options<ReqExt extends Req = Req, ResExt extends Res = Res>(
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
-    options<ReqExt = {}, ResExt = {}>(
+    options<ReqExt extends Req = Req, ResExt extends Res = Res>(
       pattern: string | RegExp,
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
 
-    trace<ReqExt = {}, ResExt = {}>(
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+    trace<ReqExt extends Req = Req, ResExt extends Res = Res>(
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
-    trace<ReqExt = {}, ResExt = {}>(
+    trace<ReqExt extends Req = Req, ResExt extends Res = Res>(
       pattern: string | RegExp,
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
 
-    patch<ReqExt = {}, ResExt = {}>(
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+    patch<ReqExt extends Req = Req, ResExt extends Res = Res>(
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
-    patch<ReqExt = {}, ResExt = {}>(
+    patch<ReqExt extends Req = Req, ResExt extends Res = Res>(
       pattern: string | RegExp,
-      ...handlers: RequestHandler<Req & ReqExt, Res & ResExt>[]
+      ...handlers: RequestHandler<ReqExt, ResExt>[]
     ): this;
 
     run(req: Req, res: Res): Promise<void>;


### PR DESCRIPTION
A small (yet possibly breaking) change of using own generic type arguments as the sole types for `Req` and `Res` in `RequestHandler` and `Middleware`
While the syntax of `Req & ReqExt` does allow for new properties to get introduced to the request (or response), it does not allow for "modifying" the ones in `Req`/`Res`

We can preserve the fact that the `Req` and `Res` types will always extend the types passed into `nc` while also allowing a sort of "modification" (no idea what the official term for this is if there even is one)

I know this can be achieved by simply getting rid of the types in the original `nc<Req>` `Req` type that u would ever want to add on later as another type, but I think this is simply a better approach to this (sidenote: it is also how express handles it so I may have a little bias from using it)

Example usage with asserting yup schemas: 
```ts

interface CustomRequest<T = any> extends NextApiRequest {
  body: T;
}

const validateData = <T extends yup.ObjectSchema<any>>(schema: T) => {
  return async (req: CustomRequest<yup.Asserts<T>>) => {
    // ...
  };
};

const handler = nc<CustomRequest, NextApiResponse>();

handler.post(
  "/path",
  validateData(yup.object({ foo: yup.string().required() })),
  (req) => {
    req.body.foo;
    // (property) foo: string   <------
  }
);

```