### PR TITLE
fix onNoMatch problematic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const handler = nc({
     console.error(err.stack);
     res.status(500).end("Something broke!");
   },
-  onNoMatch: (req, res, next) => {
+  onNoMatch: (req, res) => {
     res.status(404).end("Page is not found");
   },
 })


### PR DESCRIPTION
`onNoMatch` does not pass `next` args. but the `next` argument is used in the example.