### PR TITLE
typescript: added export for types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,16 +1,16 @@
 declare module "next-connect" {
   import { IncomingMessage, ServerResponse } from "http";
 
-  type NextHandler = (err?: any) => void;
-  type Middleware<Req, Res> = NextConnect<Req, Res> | RequestHandler<Req, Res>;
+  export type NextHandler = (err?: any) => void;
+  export type Middleware<Req, Res> = NextConnect<Req, Res> | RequestHandler<Req, Res>;
 
-  type RequestHandler<Req, Res> = (
+  export type RequestHandler<Req, Res> = (
     req: Req,
     res: Res,
     next: NextHandler
   ) => any | Promise<any>;
 
-  type ErrorHandler<Req, Res> = (
+  export type ErrorHandler<Req, Res> = (
     err: any,
     req: Req,
     res: Res,


### PR DESCRIPTION
# Summary

issue: https://github.com/hoangvvo/next-connect/issues/177

I wanted to use the middleware as part a toolset with:
* [Zod](https://github.com/colinhacks/zod)
* [Next.js API routes](https://nextjs.org/docs/api-routes/introduction)

But the type `NextHandler` isn't exported

## How I fixed it

Export all the typescript types


## Example code 

```ts

import type { NextApiRequest, NextApiResponse } from 'next';
import nc from 'next-connect';
import { AnyZodObject, z } from 'zod';

export const LoginSchema = z.object({
  userId: z.string().min(2),
  password: z.string().min(6),
});

export type Login = z.infer<typeof LoginSchema>;

type Data = {
  name: string;
};

// this comes from next-connect but NC doesn't export it 🤔
type NextHandler = (err?: any) => void;

const validate =
  (schema: AnyZodObject) =>
  async (req: NextApiRequest, res: NextApiResponse, next: NextHandler) => {
    try {
      const body = JSON.parse(req.body);
      await schema.parseAsync(body);
      return next();
    } catch (error) {
      console.log('[LOG TODO]: validate error', error);
      return res.status(400).json(error);
    }
  };

const handler = nc({
  onError: (err, req: NextApiRequest, res: NextApiResponse, next) => {
    console.error(err.stack);
    res.status(500).end('Something broke!');
  },
  onNoMatch: (req: NextApiRequest, res: NextApiResponse, next) => {
    res.status(404).end('Page is not found');
  },
})
  .use(validate(LoginSchema))
  .get((req: NextApiRequest, res: NextApiResponse<Data>) => {
    res.json({ name: 'John Doe' });
  })
  .post((req, res) => {
    console.log('>>> req.body', req.body);
    res.json({ hello: 'world' });
  })
  .put(async (req, res) => {
    res.end('async/await is also supported!');
  })
  .patch(async (req, res) => {
    throw new Error('Throws me around! Error can be caught and handled.');
  });

export default handler;


```