### PR TITLE
fix: make sure handler is resolvable

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,10 @@ handler
   });
 ```
 
-**Note:** If the instance is used as a sub-application, this option is ignored.
+**Note:**
+
+- If the instance is used as a sub-application, this option is ignored.
+- Calling _next(err)_ or throwing error will lead to UNDEFINED behavior.
 
 #### options.onNoMatch
 
@@ -151,7 +154,10 @@ function onNoMatch(req, res) {
 const handler = nc({ onNoMatch });
 ```
 
-**Note:** If the instance is used as a sub-application, this option is ignored.
+**Note:**
+
+- If the instance is used as a sub-application, this option is ignored.
+- Throwing error will lead to UNDEFINED behavior.
 
 #### options.attachParams
 
@@ -319,6 +325,22 @@ export async function getServerSideProps({ req, res }) {
     props: {},
   };
 }
+```
+
+3/ **FORGET** to call `next()` in last middleware while using `handler.run()`:
+
+```js
+const handler = nc()
+  .use((req, res, next) => {
+    next();
+  })
+  .use((req, res) => {
+    req.foo = "bar";
+    // Not calling next() or next(err) here;
+  });
+
+// BAD: This will never finish
+await handler.run(req, res);
 ```
 
 ## Recipes

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ const handler = nc({
 export default handler;
 ```
 
+**NOTE:** Make sure the response is sent or `handler()` will never resolve (unless `options.disableResponseWait` is `true`).
+
 For quick migration from [Custom Express server](https://nextjs.org/docs/advanced-features/custom-server), simply replacing `express()` _and_ `express.Router()` with `nc()` and follow the [match multiple routes recipe](#catch-all).
 
 For usage in pages with [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering), see [`.run`](#runreq-res).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-connect",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "The method routing and middleware layer for Next.js (and many others)",
   "keywords": [
     "javascript",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -27,6 +27,7 @@ declare module "next-connect" {
     onError?: ErrorHandler<Req, Res>;
     onNoMatch?: NoMatchHandler<Req, Res>;
     attachParams?: boolean;
+    disableResponseWait?: boolean;
   }
   interface NextConnect<Req, Res> {
     (req: Req, res: Res): Promise<void>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,14 @@ declare module "next-connect" {
   import { IncomingMessage, ServerResponse } from "http";
 
   export type NextHandler = (err?: any) => void;
-  export type Middleware<Req, Res> = NextConnect<Req, Res> | RequestHandler<Req, Res>;
+  export type Middleware<Req, Res> =
+    | NextConnect<Req, Res>
+    | RequestHandler<Req, Res>;
+
+  export type NoMatchHandler<Req, Res> = (
+    req: Req,
+    res: Res
+  ) => any | Promise<any>;
 
   export type RequestHandler<Req, Res> = (
     req: Req,
@@ -13,13 +20,12 @@ declare module "next-connect" {
   export type ErrorHandler<Req, Res> = (
     err: any,
     req: Req,
-    res: Res,
-    next: NextHandler
+    res: Res
   ) => any | Promise<any>;
 
   export interface Options<Req, Res> {
     onError?: ErrorHandler<Req, Res>;
-    onNoMatch?: RequestHandler<Req, Res>;
+    onNoMatch?: NoMatchHandler<Req, Res>;
     attachParams?: boolean;
   }
   interface NextConnect<Req, Res> {

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,10 @@ export default function factory({
   async function nc(req, res) {
     let closeP;
     if ("once" in res)
-      closeP = new Promise((resolve) =>
-        isResSent(res) ? resolve() : res.once("close", resolve)
-      );
+      closeP = new Promise((resolve) => {
+        res.once("close", resolve);
+        if (isResSent(res)) resolve();
+      });
     nc.handle(req, res, (err, next) =>
       err
         ? onError(err, req, res, () => next())

--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,17 @@ export default function factory({
   attachParams = false,
 } = {}) {
   async function nc(req, res) {
+    let closeP;
+    if ("once" in res)
+      closeP = new Promise((resolve) =>
+        isResSent(res) ? resolve() : res.once("close", resolve)
+      );
     nc.handle(req, res, (err, next) =>
       err
         ? onError(err, req, res, () => next())
         : !isResSent(res) && onNoMatch(req, res)
     );
+    await closeP;
   }
   nc.routes = [];
   const _use = Trouter.prototype.use.bind(nc);

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,11 @@ export default function factory({
   onError = onerror,
   onNoMatch = onerror.bind(null, { status: 404, message: "not found" }),
   attachParams = false,
+  disableResponseWait = false,
 } = {}) {
   async function nc(req, res) {
     let closeP;
-    if ("once" in res)
+    if (!disableResponseWait && "once" in res)
       closeP = new Promise((resolve) => {
         res.once("close", resolve);
         if (isResSent(res)) resolve();

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default function factory({
     let closeP;
     if (!disableResponseWait && "once" in res)
       closeP = new Promise((resolve) => {
-        res.once("close", resolve);
+        res.once("finish", resolve);
         if (isResSent(res)) resolve();
       });
     nc.handle(req, res, (err, next) =>

--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,9 @@ export default function factory({
   disableResponseWait = false,
 } = {}) {
   async function nc(req, res) {
-    let closeP;
+    let finishP;
     if (!disableResponseWait && "once" in res)
-      closeP = new Promise((resolve) => {
+      finishP = new Promise((resolve) => {
         res.once("finish", resolve);
         if (isResSent(res)) resolve();
       });
@@ -23,7 +23,7 @@ export default function factory({
         ? onError(err, req, res, () => next())
         : !isResSent(res) && onNoMatch(req, res)
     );
-    await closeP;
+    await finishP;
   }
   nc.routes = [];
   const _use = Trouter.prototype.use.bind(nc);

--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,10 @@ export default function factory({
   onNoMatch = onerror.bind(null, { status: 404, message: "not found" }),
   attachParams = false,
 } = {}) {
-  function nc(req, res) {
+  async function nc(req, res) {
     nc.handle(req, res, (err, next) =>
       err
-        ? onError(err, req, res, next)
+        ? onError(err, req, res, () => next())
         : !isResSent(res) && onNoMatch(req, res)
     );
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -64,6 +64,16 @@ describe("nc()", () => {
   it("is a function with two argument", () => {
     assert(typeof nc() === "function" && nc().length === 2);
   });
+
+  it("returns a resolved promise", (done) => {
+    nc()
+      .get((req, res, next) => {
+        next()
+      })({ method: "GET", url: "/" }, { end: () => null })
+      .then(() => {
+        done()
+      });
+  });
 });
 
 describe(".METHOD", () => {
@@ -307,26 +317,6 @@ describe("use()", () => {
 });
 
 describe("handle()", () => {
-  it("response with default 404 on no match", () => {
-    const handler = nc();
-    handler.post((req, res) => {
-      res.end("");
-    });
-
-    const app = createServer(handler);
-    return request(app).get("/").expect(404);
-  });
-
-  it("response with custom 404 on no match", () => {
-    function onNoMatch(req, res) {
-      res.end("");
-    }
-
-    const handler2 = nc({ onNoMatch });
-    const app = createServer(handler2);
-    return request(app).get("/").expect(200);
-  });
-
   it("call .find with pathname instead of url", () => {
     const handler = nc().get("/test", (req, res) => res.end("ok"));
     const app = createServer(handler);
@@ -452,6 +442,28 @@ describe("onError", () => {
     handler2.get(async (req, res) => res.end("ok"));
     const app = createServer(handler2);
     return request(app).get("/").expect("Something failed");
+  });
+});
+
+describe("onNoMatch", () => {
+  it("response with default 404 on no match", () => {
+    const handler = nc();
+    handler.post((req, res) => {
+      res.end("");
+    });
+
+    const app = createServer(handler);
+    return request(app).get("/").expect(404);
+  });
+
+  it("response with custom 404 on no match", () => {
+    function onNoMatch(req, res) {
+      res.end("");
+    }
+
+    const handler2 = nc({ onNoMatch });
+    const app = createServer(handler2);
+    return request(app).get("/").expect(200);
   });
 });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,7 +73,7 @@ describe("nc()", () => {
       .then(done);
   });
 
-  it("does not resolve if res is not closed", (done) => {
+  it("does not resolve if res is not finshed", (done) => {
     const handler = nc().get(() => {
       /* noop */
     });
@@ -92,11 +92,10 @@ describe("nc()", () => {
       .then(() => undefined);
   });
 
-  it("resolves after res close event", (done) => {
+  it("resolves after res 'finish' event", (done) => {
     const handler = nc().get((req, res) => {
       // minus 3 is 1
       res.end("hello");
-      res.finished = true;
     });
     const app = createServer((req, res) => {
       handler(req, res).then(done);
@@ -107,12 +106,13 @@ describe("nc()", () => {
       .then(() => undefined);
   });
 
-  it("resolves immediately if res is sent", (done) => {
+  it("resolves immediately if res is already sent", (done) => {
     const handler = nc().get(() => {
       /* noop */
     });
     const app = createServer((req, res) => {
       res.end("quick math", () => {
+        assert(res.finished || res.headersSent, "res.finished must be true")
         handler(req, res).then(done);
       });
     });


### PR DESCRIPTION
There was a bug that prevent `await handler(req, res)` to be finished. This aims to solve it by resolving when `end` event is called in response object.

It is possible to disable this behavior (to resolve immediately) using `options.disableResponseWait`.

Fixed #179 