### PR TITLE
security: always return generic 500 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,11 @@ const router = createRouter()
       // https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props#notfound
       return { props: { notFound: true } };
     }
-    return {
-      props: { user, updated: true },
-    };
+    return { props: { user } };
   })
   .post(async (req, res) => {
     const user = await updateUser(req);
-    return {
-      props: { user, updated: true },
-    };
+    return { props: { user, updated: true } };
   });
 
 export async function getServerSideProps({ req, res }) {
@@ -214,7 +210,7 @@ router.post("/api/users", (req, res, next) => {
 });
 router.put("/api/user/:id", (req, res, next) => {
   // https://nextjs.org/docs/routing/dynamic-routes
-  res.end(`User ${req.query.id} updated`);
+  res.end(`User ${req.params.id} updated`);
 });
 
 // Next.js already handles routing (including dynamic routes), we often
@@ -238,7 +234,7 @@ Create a handler to handle incoming requests.
 **options.onError**
 
 Accepts a function as a catch-all error handler; executed whenever a handler throws an error.
-By default, it responds with status code `500` and an error stack if any.
+By default, it responds with a generic `500 Internal Server Error` while logging the error to `console`.
 
 ```javascript
 function onError(err, req, res) {
@@ -250,9 +246,6 @@ function onError(err, req, res) {
 
 export default router.handler({ onError });
 ```
-
-> **Warning**
-> The default option prints the error stack, which might be a security risk. Consider defining a custom one like the above to mitigate the risk.
 
 **options.onNoMatch**
 
@@ -367,11 +360,11 @@ export default createRouter().use(a).use(b);
 
 // api/foo.js
 import router from "api-libs/base";
-export default router.get(x);
+export default router.get(x).handler();
 
 // api/bar.js
 import router from "api-libs/base";
-export default router.get(y);
+export default router.get(y).handler();
 ```
 
 This is because, in each API Route, the same router instance is mutated, leading to undefined behaviors.
@@ -383,11 +376,11 @@ export default createRouter().use(a).use(b);
 
 // api/foo.js
 import router from "api-libs/base";
-export default router.clone().get(x);
+export default router.clone().get(x).handler();
 
 // api/bar.js
 import router from "api-libs/base";
-export default router.clone().get(y);
+export default router.clone().get(y).handler();
 ```
 
 3. **DO NOT** use response function like `res.(s)end` or `res.redirect` inside `getServerSideProps`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-connect",
-  "version": "0.12.2",
+  "version": "1.0.0-next.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-connect",
-      "version": "0.12.2",
+      "version": "1.0.0-next.0",
       "license": "MIT",
       "dependencies": {
         "regexparam": "^2.0.1"
@@ -23,8 +23,12 @@
         "eslint-plugin-prettier": "^4.2.1",
         "prettier": "^2.7.1",
         "tap": "^16.3.0",
+        "tinyspy": "^1.0.0",
         "ts-node": "^10.8.1",
         "typescript": "^4.7.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5419,6 +5423,15 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/tinyspy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.0.tgz",
+      "integrity": "sha512-FI5B2QdODQYDRjfuLF+OrJ8bjWRMCXokQPcwKm0W3IzcbUmBNv536cQc7eXGoAuXphZwgx1DFbqImwzz08Fnhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -9603,6 +9616,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "tinyspy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.0.tgz",
+      "integrity": "sha512-FI5B2QdODQYDRjfuLF+OrJ8bjWRMCXokQPcwKm0W3IzcbUmBNv536cQc7eXGoAuXphZwgx1DFbqImwzz08Fnhw==",
       "dev": true
     },
     "to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1",
     "tap": "^16.3.0",
+    "tinyspy": "^1.0.0",
     "ts-node": "^10.8.1",
     "typescript": "^4.7.4"
   },

--- a/src/node.ts
+++ b/src/node.ts
@@ -39,9 +39,9 @@ export class NodeRouter<
     this.prepareRequest(req, res, result);
     return Router.exec(result.fns, req, res);
   }
-  handler(options?: HandlerOptions<RequestHandler<Req, Res>>) {
-    const onNoMatch = options?.onNoMatch || onnomatch;
-    const onError = options?.onError || onerror;
+  handler(options: HandlerOptions<RequestHandler<Req, Res>> = {}) {
+    const onNoMatch = options.onNoMatch || onnomatch;
+    const onError = options.onError || onerror;
     return async (req: Req, res: Res) => {
       const result = this.find(
         req.method as HttpMethod,
@@ -67,8 +67,8 @@ function onnomatch(req: IncomingMessage, res: ServerResponse) {
 }
 function onerror(err: unknown, req: IncomingMessage, res: ServerResponse) {
   res.statusCode = 500;
-  // @ts-expect-error: we render regardless
-  res.end(err?.stack);
+  console.error(err);
+  res.end("Internal Server Error");
 }
 
 export function getPathname(url: string) {


### PR DESCRIPTION
For security reason, we should always respond with "internal server error" while logging the error to console instead of responding with the error stack

Close #118