### PR TITLE
Remove necessity for next to always be defined when using .run

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -77,7 +77,7 @@ export class Router<H extends FunctionLike> {
     ...args: Parameters<H>
   ): Promise<unknown> {
     let i = 0;
-    const next = () => fns[++i](...args, next);
+    const next = () => fns[++i]?.(...args, next);
     return fns[i](...args, next);
   }
 


### PR DESCRIPTION
It is possible to hit a scenario where there is no "next" function but if I want to have universal middleware it gets an invalid function back from next-connect when i try to call it.

IE:
```
const withGlobal = () =>
  createRouter().use(async (req, res, next) => {
    const nextResults = next ? await next() : undefined;
    return {
      ...nextResults,
      props: { ...nextResults?.props, global: { yo: "yo" } },
    };
  });
```
and in the page i have
```
export const getServerSideProps = async (ctx: GetServerSidePropsContext) =>
  await createRouter()
    .use(withGlobal())
    .run(ctx.req, ctx.res);
```

Running this throws `TypeError: Function.prototype.apply was called on undefined, which is a undefined and not a function`

which i traced back to this file in Router.exec line 80 it expects there to be a function inside fns at ++i but since i'm using run (and not a get or post handler) i shouldnt need to add anymore fns on the end of this.

FYI 
```
export const getServerSideProps = async (ctx: GetServerSidePropsContext) =>
  await createRouter()
    .use(withGlobal())
    .use(() => ({}))
    .run(ctx.req, ctx.res);
```
*does* work because creates the fn that next() is looking for, but its ugly and idontwanna