### PR TITLE
docs: update router return statement to include type casting for next 14 app router

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ router
     return NextResponse.json({ user });
   });
 
-// Make sure to cast the handler to `Promise<NextResponse>` to prevent type error with next.js 14 app router in production/preview deployments.
+// Make sure to cast the handler return to `Promise<NextResponse>` to prevent type error with next.js 14 app router in production/preview deployments.
 export async function GET(request: NextRequest, ctx: RequestContext) {
   return router.run(request, ctx) as Promise<NextResponse>;
 }

--- a/README.md
+++ b/README.md
@@ -157,12 +157,13 @@ router
     return NextResponse.json({ user });
   });
 
+// Make sure to cast the handler to `Promise<NextResponse>` to prevent type error with next.js 14 app router in production/preview deployments.
 export async function GET(request: NextRequest, ctx: RequestContext) {
-  return router.run(request, ctx);
+  return router.run(request, ctx) as Promise<NextResponse>;
 }
 
 export async function PUT(request: NextRequest, ctx: RequestContext) {
-  return router.run(request, ctx);
+  return router.run(request, ctx) as Promise<NextResponse>;
 }
 ```
 


### PR DESCRIPTION
### 
Fixes https://github.com/hoangvvo/next-connect/issues/241


This PR updates the readme to include a life saving section that fixes an error with h Next.js 14 app router in production/preview using typescript


### Before
![image](https://github.com/hoangvvo/next-connect/assets/62995161/b5fa3698-eaaf-4d53-ada9-279ed7e86d5e)

### After
![image](https://github.com/hoangvvo/next-connect/assets/62995161/718b9304-27e2-457e-a66b-0369ce1d8698)

